### PR TITLE
v0.7.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v0.7.3] - 2026-06-22
+- Fixed residue zoom so the `Residue Zoom extraRadius` and `minRadius` settings are forwarded to Mol*.
+- Added regression tests for residue zoom option forwarding.
+- Kept the `RP_name_table_uniprot.csv` chain label lookup and related chain/residue selection fixes.
+
 ## [v0.7.2] - 2026-06-22
 - Added per-column `Show Advanced Mol* Controls` / `Hide Advanced Mol* Controls` button below each viewer.
 - Advanced Mol* interface panels (sequence, menu, controls, log) are now hidden by default to reduce UI clutter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## [v0.7.3] - 2026-06-22
-- Fixed residue zoom so the `Residue Zoom extraRadius` and `minRadius` settings are forwarded to Mol*.
-- Added regression tests for residue zoom option forwarding.
-- Kept the `RP_name_table_uniprot.csv` chain label lookup and related chain/residue selection fixes.
+- Fixed residue zoom wiring in `App.tsx` so `Residue Zoom extraRadius` and `minRadius` are passed through to Mol* focus calls.
+- Added regression coverage for residue zoom option forwarding in `viewerHelpers` tests.
+- Included chain/residue selection reliability fixes and chain label improvements using `RP_name_table_uniprot.csv` lookup data.
 
 ## [v0.7.2] - 2026-06-22
-- Added per-column `Show Advanced Mol* Controls` / `Hide Advanced Mol* Controls` button below each viewer.
-- Advanced Mol* interface panels (sequence, menu, controls, log) are now hidden by default to reduce UI clutter.
-- Core Mol* `3D Canvas` remains visible by default, with advanced panels available on demand for power users.
+- Added per-column `Show Advanced Mol* Controls` / `Hide Advanced Mol* Controls` toggle below each viewer.
+- Hid non-canvas Mol* interface panels (sequence, menu, controls, log) by default to reduce UI clutter.
+- Kept the core Mol* `3D Canvas` visible, with advanced panels available on demand.
 
 ## [v0.7.1] - 2026-05-29
 - Save/Load session buttons added.

--- a/DeveloperGuide.md
+++ b/DeveloperGuide.md
@@ -256,8 +256,10 @@ The app header version text is read directly from `package.json` in `src/compone
 1. Bump version using one of the commands above.
 2. Add/update the release entry in `CHANGELOG.md`.
 3. Run tests (for example `npm test` and any targeted E2E tests as needed).
-4. Commit version/doc/code changes together.
-5. Optionally add a git tag (e.g., `vX.Y.Z`) when publishing.
+4. Commit version/doc/code changes together and push to `main`.
+5. Deploy the PWA build with `npm run deploy`.
+6. Create and push a release tag (e.g., `vX.Y.Z`).
+7. Publish the GitHub release notes for the tag.
 
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 Ribocode orchestrates a User Interface (UI) based on two styled [Mol*](https://github.com/molstar/molstar) viewers and is specifically geared for comparing two [ribosome](https://en.wikipedia.org/wiki/Ribosome) datasets in [3D](https://en.wikipedia.org/wiki/Three-dimensional_space). It is deployed as a [Progressive Web App (PWA)](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) via GitHub Pages that can be easily duplicated. The latest version is released at the following URL:
 * https://ribocode-slola.github.io/ribocode1/
 
+An official Ribocode release includes deployment of the GitHub Pages PWA build.
+
 The user requires a recent [Web browser](https://en.wikipedia.org/wiki/Web_browser) (e.g. [Firefox](https://www.firefox.com/)) that will run [JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript).
 
 Once installed as a PWA, Ribocode can be used offline.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ribocode1",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ribocode1",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ribocode1",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -710,7 +710,9 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
         sync: syncEnabled,
         syncPluginRef: viewerB.ref,
         residueId: selectedResidueIdAlignedTo,
-        insCode: residueInfoAlignedTo.residueLabels.get(selectedResidueIdAlignedTo)?.insCode
+        insCode: residueInfoAlignedTo.residueLabels.get(selectedResidueIdAlignedTo)?.insCode,
+        zoomExtraRadius,
+        zoomMinRadius
     });
     const residueZoomAAligned = makeZoomHandler({
         pluginRef: viewerA.ref,
@@ -720,7 +722,9 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
         sync: syncEnabled,
         syncPluginRef: viewerB.ref,
         residueId: selectedResidueIdAligned,
-        insCode: residueInfoAligned.residueLabels.get(selectedResidueIdAligned)?.insCode
+        insCode: residueInfoAligned.residueLabels.get(selectedResidueIdAligned)?.insCode,
+        zoomExtraRadius,
+        zoomMinRadius
     });
     const residueZoomBAlignedTo = makeZoomHandler({
         pluginRef: viewerB.ref,
@@ -730,7 +734,9 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
         sync: syncEnabled,
         syncPluginRef: viewerA.ref,
         residueId: selectedResidueIdAlignedTo,
-        insCode: residueInfoAlignedTo.residueLabels.get(selectedResidueIdAlignedTo)?.insCode
+        insCode: residueInfoAlignedTo.residueLabels.get(selectedResidueIdAlignedTo)?.insCode,
+        zoomExtraRadius,
+        zoomMinRadius
     });
     const residueZoomBAligned = makeZoomHandler({
         pluginRef: viewerB.ref,
@@ -740,7 +746,9 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
         sync: syncEnabled,
         syncPluginRef: viewerA.ref,
         residueId: selectedResidueIdAligned,
-        insCode: residueInfoAligned.residueLabels.get(selectedResidueIdAligned)?.insCode
+        insCode: residueInfoAligned.residueLabels.get(selectedResidueIdAligned)?.insCode,
+        zoomExtraRadius,
+        zoomMinRadius
     });
 
     // Unified robust delete handler for any representation

--- a/src/components/buttons/select/Residue.test.tsx
+++ b/src/components/buttons/select/Residue.test.tsx
@@ -4,8 +4,8 @@
  * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Andy Turner <agdturner@gmail.com>
- * @version 1.0.0
- * @lastModified 2026-04-24
+ * @version 1.0.1
+ * @lastModified 2026-06-22
  * @see https://github.com/ribocode-slola/ribocode1
  */
 import { vi } from 'vitest';
@@ -21,7 +21,7 @@ describe('ResidueSelectButton', () => {
         ['30', { id: '30', name: 'SER 30', compId: 'SER', seqNumber: 30, insCode: '' }],
     ]);
 
-    it('renders with default label and options', () => {
+    it('renders with default label and option display names', () => {
         const { getByLabelText, getByText } = render(
             <ResidueSelectButton
                 disabled={false}
@@ -51,7 +51,7 @@ describe('ResidueSelectButton', () => {
         expect(getByLabelText('Pick Residue')).toBeInTheDocument();
     });
 
-    it('shows selected residue label', () => {
+    it('shows selected residue by ID (not by name string)', () => {
         const { getByLabelText } = render(
             <ResidueSelectButton
                 disabled={false}
@@ -61,7 +61,8 @@ describe('ResidueSelectButton', () => {
                 id="select-residue-test"
             />
         );
-        expect((getByLabelText('Select Residue') as HTMLSelectElement).value).toBe('ALA 20');
+        // The <select> value is now the residue ID, not the display name
+        expect((getByLabelText('Select Residue') as HTMLSelectElement).value).toBe('20');
     });
 
     it('calls onSelect with residueId when option is chosen', () => {
@@ -75,7 +76,8 @@ describe('ResidueSelectButton', () => {
                 id="test-residue-select-onselect"
             />
         );
-        fireEvent.change(getByLabelText('Select Residue'), { target: { value: 'SER 30' } });
+        // Fire change with the residue ID as value (options use IDs as values)
+        fireEvent.change(getByLabelText('Select Residue'), { target: { value: '30' } });
         expect(onSelect).toHaveBeenCalledWith('30');
     });
 
@@ -91,4 +93,57 @@ describe('ResidueSelectButton', () => {
         );
         expect(getByLabelText('Select Residue')).toBeDisabled();
     });
+
+    it('renders options in ascending sequence-number order', () => {
+        // Provide residues in non-sorted order to verify sorting
+        const unorderedLabels = new Map<string, ResidueLabelInfo>([
+            ['30', { id: '30', name: 'SER 30', compId: 'SER', seqNumber: 30, insCode: '' }],
+            ['10', { id: '10', name: 'GLY 10', compId: 'GLY', seqNumber: 10, insCode: '' }],
+            ['20', { id: '20', name: 'ALA 20', compId: 'ALA', seqNumber: 20, insCode: '' }],
+        ]);
+        const { getAllByRole } = render(
+            <ResidueSelectButton
+                disabled={false}
+                residueLabels={unorderedLabels}
+                selectedResidueId={''}
+                onSelect={() => {}}
+                id="residue-order-test"
+            />
+        );
+        const options = getAllByRole('option').filter(o => (o as HTMLOptionElement).value !== '');
+        expect(options.map(o => (o as HTMLOptionElement).value)).toEqual(['10', '20', '30']);
+    });
+
+    it('uses insertion code as secondary sort key', () => {
+        const labelsWithInsCode = new Map<string, ResidueLabelInfo>([
+            ['70B', { id: '70B', name: 'LEU 70B', compId: 'LEU', seqNumber: 70, insCode: 'B' }],
+            ['70',  { id: '70',  name: 'LEU 70',  compId: 'LEU', seqNumber: 70, insCode: '' }],
+            ['70A', { id: '70A', name: 'LEU 70A', compId: 'LEU', seqNumber: 70, insCode: 'A' }],
+        ]);
+        const { getAllByRole } = render(
+            <ResidueSelectButton
+                disabled={false}
+                residueLabels={labelsWithInsCode}
+                selectedResidueId={''}
+                onSelect={() => {}}
+                id="residue-inscode-test"
+            />
+        );
+        const options = getAllByRole('option').filter(o => (o as HTMLOptionElement).value !== '');
+        expect(options.map(o => (o as HTMLOptionElement).value)).toEqual(['70', '70A', '70B']);
+    });
+
+    it('the select id matches the provided id prop', () => {
+        const { getByLabelText } = render(
+            <ResidueSelectButton
+                disabled={false}
+                residueLabels={residueLabels}
+                selectedResidueId={''}
+                onSelect={() => {}}
+                id="my-residue-id"
+            />
+        );
+        expect((getByLabelText('Select Residue') as HTMLSelectElement).id).toBe('my-residue-id');
+    });
 });
+

--- a/src/components/buttons/select/Residue.tsx
+++ b/src/components/buttons/select/Residue.tsx
@@ -4,18 +4,18 @@
  * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Andy Turner <agdturner@gmail.com>
- * @version 1.0.0
- * @lastModified 2026-04-24
+ * @version 1.0.1
+ * @lastModified 2026-06-22
  * @see https://github.com/ribocode-slola/ribocode1
  */
 import React from 'react';
-import GenericSelectButton, { idSuffix as selectIdSuffix } from './Select';
+import { idSuffix as selectIdSuffix } from './Select';
 import { ResidueLabelInfo } from 'src/utils/residue';
 
 /**
  * Props for the ResidueSelectButton component.
  * @property disabled Whether the select button is disabled.
- * @property residueIds The array of residue IDs to select from.
+ * @property residueLabels The map of residue IDs to labels to select from.
  * @property selectedResidueId The currently selected residue ID.
  * @property onSelect Callback function when a residue ID is selected.
  * @property label Optional label for the select button.
@@ -32,12 +32,18 @@ export interface ResidueSelectButtonProps {
 
 /**
  * A select button for residues.
+ *
+ * Uses the residue ID as the underlying `<option>` value and displays the
+ * human-readable label (e.g. "LEU 70") as the option text.  This avoids the
+ * fragile name-based reverse-lookup that the previous GenericSelectButton
+ * wrapper required.
+ *
  * @param disabled Whether the select button is disabled.
- * @param residueLabels The map of residue IDs to labels to select from.
+ * @param residueLabels Map from residue ID → ResidueLabelInfo.
  * @param selectedResidueId The currently selected residue ID.
- * @param onSelect Callback function when a residue ID is selected.
- * @param label Optional label for the select button.
- * @param id A unique identifier for the select button.
+ * @param onSelect Callback invoked with the selected residue ID.
+ * @param label Optional label for the select element.
+ * @param id A unique identifier for the select element.
  * @returns The ResidueSelectButton component.
  */
 const ResidueSelectButton: React.FC<ResidueSelectButtonProps> = ({
@@ -48,26 +54,27 @@ const ResidueSelectButton: React.FC<ResidueSelectButtonProps> = ({
 	label,
 	id
 }) => {
-	// Map selectedResidueId to its label value
-	const selectedLabel = selectedResidueId ? residueLabels.get(String(selectedResidueId).trim())?.name || '' : '';
-	// When a label is selected, find the corresponding residueId (as trimmed string)
-	const handleSelect = (selectedLabel: string) => {
-		for (const [id, info] of residueLabels.entries()) {
-			if (info.name === selectedLabel) {
-				onSelect(String(id).trim());
-				break;
-			}
-		}
-	};
+	// Sort by sequence number (ascending), with insertion code as tiebreaker
+	const orderedEntries = Array.from(residueLabels.entries()).sort(
+		([, a], [, b]) =>
+			a.seqNumber - b.seqNumber || a.insCode.localeCompare(b.insCode)
+	);
 	return (
-		<GenericSelectButton
-			label={label || 'Select Residue'}
-			options={Array.from(residueLabels.values()).map(info => info.name)}
-			selected={selectedLabel}
-			onSelect={handleSelect}
-			disabled={disabled}
-			id={id ?? selectIdSuffix}
-		/>
+		<label>
+			{label || 'Select Residue'}
+			<select
+				className="msp-select msp-form-control"
+				value={selectedResidueId ?? ''}
+				onChange={e => onSelect(e.target.value)}
+				disabled={disabled}
+				id={id ?? selectIdSuffix}
+			>
+				<option value="" disabled>...</option>
+				{orderedEntries.map(([residueId, info]) => (
+					<option key={residueId} value={residueId}>{info.name}</option>
+				))}
+			</select>
+		</label>
 	);
 };
 

--- a/src/hooks/useUpdateChainInfo.test.tsx
+++ b/src/hooks/useUpdateChainInfo.test.tsx
@@ -1,11 +1,11 @@
 /**
  * Test suite for useUpdateChainInfo hook.
- * 
+ *
  * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
- * 
+ *
  * @author Andy Turner <agdturner@gmail.com>
- * @version 1.0.0
- * @lastModified 2026-04-24
+ * @version 1.0.1
+ * @lastModified 2026-06-22
  * @see https://github.com/ribocode-slola/ribocode1
  */
 import { vi } from 'vitest';
@@ -13,20 +13,22 @@ import { renderHook } from '@testing-library/react';
 import { useUpdateChainInfo } from './useUpdateChainInfo';
 
 describe('useUpdateChainInfo', () => {
-  it('updates chain info and subunit-to-chain mapping when structure is present', () => {
-    // Mock pluginRef and structure
-    const mockChainLabels = new Map([
-      ['A', 'Chain A'],
-      ['B', 'Chain B'],
-    ]);
-    const mockSubunitToChainIds = new Map([
-      ['Large', new Set(['A'])],
-      ['Small', new Set(['B'])],
-    ]);
+  it('updates chain info using auth_asym_id labels from model hierarchy', () => {
+    // Mock structure using model.atomicHierarchy.chains (as getChainInfo expects)
     const mockStructureObj = {
       units: [
-        { chainGroupId: 'A', label: 'Chain A', subunit: 'Large' },
-        { chainGroupId: 'B', label: 'Chain B', subunit: 'Small' },
+        {
+          kind: 0,
+          model: {
+            atomicHierarchy: {
+              chains: {
+                _rowCount: 2,
+                auth_asym_id: { value: (i: number) => ['A', 'B'][i] },
+                label_asym_id: { value: (i: number) => ['AA', 'BB'][i] },
+              }
+            }
+          }
+        }
       ],
     };
     const pluginRef = { current: {
@@ -54,17 +56,81 @@ describe('useUpdateChainInfo', () => {
         'TestLabel'
       )
     );
-    // Check that setChainInfo was called with a function updater
+    // setChainInfo is called with a functional updater
     expect(setChainInfo).toHaveBeenCalled();
     const updater = setChainInfo.mock.calls[0][0];
     const result = updater({ chainLabels: new Map() });
-    expect(result).toEqual({ chainLabels: mockChainLabels });
+    // Labels are now "labelId [auth authId]" format
+    expect(result.chainLabels.get('A')).toBe('AA [auth A]');
+    expect(result.chainLabels.get('B')).toBe('BB [auth B]');
 
-    // Check that setSubunitToChainIds was called with a function updater
+    // All chains now map to the 'default' subunit
     expect(setSubunitToChainIds).toHaveBeenCalled();
     const subunitUpdater = setSubunitToChainIds.mock.calls[0][0];
     const subunitResult = subunitUpdater(new Map());
-    expect(subunitResult).toEqual(mockSubunitToChainIds);
+    expect(subunitResult.get('default')).toEqual(new Set(['A', 'B']));
+  });
+
+  it('enriches labels with family names when rpNameLookup is provided', () => {
+    const rpNameLookup = new Map([['P61247', 'eS1']]);
+    const mockStructureObj = {
+      units: [
+        {
+          kind: 0,
+          model: {
+            atomicHierarchy: {
+              chains: {
+                _rowCount: 1,
+                auth_asym_id: { value: () => 'A' },
+                label_asym_id: { value: () => 'AA' },
+                label_entity_id: { value: () => '1' },
+              }
+            },
+            sourceData: {
+              data: {
+                db: {
+                  struct_ref: {
+                    _rowCount: 1,
+                    entity_id: { value: () => '1' },
+                    pdbx_db_accession: { value: () => 'P61247' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ],
+    };
+    const pluginRef = { current: {
+      managers: {
+        structure: {
+          hierarchy: {
+            current: {
+              structures: [
+                { cell: { transform: { ref: 'ref1' }, obj: { data: mockStructureObj } } },
+              ],
+            },
+          },
+        },
+      },
+    }};
+    const setChainInfo = vi.fn();
+    const setSubunitToChainIds = vi.fn();
+    renderHook(() =>
+      useUpdateChainInfo(
+        pluginRef as any,
+        'ref1',
+        {},
+        setChainInfo,
+        setSubunitToChainIds,
+        'TestLabel',
+        rpNameLookup
+      )
+    );
+    expect(setChainInfo).toHaveBeenCalled();
+    const updater = setChainInfo.mock.calls[0][0];
+    const result = updater({ chainLabels: new Map() });
+    expect(result.chainLabels.get('A')).toBe('eS1 [AA]');
   });
 
   it('does nothing if pluginRef.current is null', () => {

--- a/src/hooks/useUpdateChainInfo.ts
+++ b/src/hooks/useUpdateChainInfo.ts
@@ -4,11 +4,12 @@
  * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Andy Turner <agdturner@gmail.com>
- * @version 1.0.0
- * @lastModified 2026-04-24
+ * @version 1.0.1
+ * @lastModified 2026-06-22
  * @see https://github.com/ribocode-slola/ribocode1
  */
 import { useEffect } from 'react';
+import { getChainInfo } from '../utils/chain';
 
 /**
  * Custom hook to update chain info and subunit-to-chain mapping for a Mol* structure.
@@ -19,6 +20,8 @@ import { useEffect } from 'react';
  * @param setChainInfo - Setter for chain info state.
  * @param setSubunitToChainIds - Setter for subunit-to-chain mapping state.
  * @param label - Optional label for logging/debugging.
+ * @param rpNameLookup - Optional Map<uniprotCode, familyName> from parseRpNameTable() to
+ *   enrich chain labels with gene family names (e.g. "uS2 [AA]" instead of "AA [auth A]").
  */
 export function useUpdateChainInfo(
   pluginRef: React.RefObject<any>,
@@ -26,7 +29,8 @@ export function useUpdateChainInfo(
   molstar: any,
   setChainInfo: React.Dispatch<React.SetStateAction<{ chainLabels: Map<string, string> }>>,
   setSubunitToChainIds: React.Dispatch<React.SetStateAction<Map<string, Set<string>>>>,
-  label?: string
+  label?: string,
+  rpNameLookup?: Map<string, string>
 ) {
   useEffect(() => {
     if (!pluginRef.current || !structureRef) return;
@@ -38,23 +42,18 @@ export function useUpdateChainInfo(
         (s: any) => s.cell.transform.ref === structureRef
       )?.cell.obj?.data;
       if (!structureObj) return;
-      // Extract chain labels and subunit-to-chain mapping
-      const chainLabels = new Map<string, string>();
+
+      // Use getChainInfo to extract auth-based chain labels (with optional family name enrichment)
+      const { chainLabels } = getChainInfo(structureObj, rpNameLookup);
+
+      // Build subunit-to-chain mapping (subunit defaults to 'default' for all chains)
       const subunitToChainIds = new Map<string, Set<string>>();
-      for (const unit of structureObj.units) {
-        // Use chainGroupId as the chain identifier (Mol* convention)
-        const chainId = unit.chainGroupId;
-        if (chainId === undefined || chainId === null || chainId === '') {
-          // eslint-disable-next-line no-console
-          console.warn(`[useUpdateChainInfo][${label}] Skipping unit with invalid chainGroupId:`, unit);
-          continue;
-        }
-        const labelVal = unit.label || chainId;
-        const subunit = unit.subunit || 'default';
-        chainLabels.set(chainId, labelVal);
+      for (const [chainId] of chainLabels) {
+        const subunit = 'default';
         if (!subunitToChainIds.has(subunit)) subunitToChainIds.set(subunit, new Set());
         subunitToChainIds.get(subunit)!.add(chainId);
       }
+
       if (chainLabels.size === 0) {
         // eslint-disable-next-line no-console
         console.warn(`[useUpdateChainInfo][${label}] No valid chains found in structure. State not updated.`);
@@ -96,13 +95,12 @@ export function useUpdateChainInfo(
         if (changed) return subunitToChainIds;
         return prev;
       });
-      if (label) {
-        // eslint-disable-next-line no-console
-        console.log(`[useUpdateChainInfo][${label}] chainLabels:`, chainLabels, 'subunitToChainIds:', subunitToChainIds);
-      }
+      // Debug logging disabled to avoid console spam; uncomment if needed:
+      // if (label) console.log(`[useUpdateChainInfo][${label}] chainLabels:`, chainLabels, 'subunitToChainIds:', subunitToChainIds);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.warn(`[useUpdateChainInfo][${label}] failed:`, err);
     }
-  }, [pluginRef, structureRef, molstar, setChainInfo, setSubunitToChainIds, label]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pluginRef, structureRef, molstar, setChainInfo, setSubunitToChainIds, label, rpNameLookup]);
 }

--- a/src/hooks/useUpdateResidueInfo.ts
+++ b/src/hooks/useUpdateResidueInfo.ts
@@ -4,22 +4,26 @@
  * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
  *
  * @author Andy Turner <agdturner@gmail.com>
- * @version 1.0.0
- * @lastModified 2026-04-24
+ * @version 1.0.1
+ * @lastModified 2026-06-22
  * @see https://github.com/ribocode-slola/ribocode1
  */
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { ResidueLabelInfo } from '../utils/residue';
 
 /**
  * Custom hook to update residue info for a Mol* structure and selected chain.
+ *
+ * Whenever `selectedChainId` changes the residue list is refreshed.  If the
+ * previously selected residue ID no longer exists in the new chain, the
+ * selection is automatically reset to the first residue of the new chain.
  *
  * @param viewerRef - Ref to the Mol* plugin UI context.
  * @param structureRef - Structure reference string.
  * @param molstar - Molstar viewer instance.
  * @param selectedChainId - Selected chain ID.
  * @param setResidueInfo - Setter for residue info state.
- * @param selectedResidueId - Selected residue ID.
+ * @param selectedResidueId - Currently selected residue ID (read-only, via ref).
  * @param setSelectedResidueId - Setter for selected residue ID.
  * @param label - Optional label for logging/debugging.
  */
@@ -33,6 +37,11 @@ export function useUpdateResidueInfo(
   setSelectedResidueId: React.Dispatch<React.SetStateAction<string>>,
   label?: string
 ) {
+  // Use a ref so we can read the latest selectedResidueId inside the effect
+  // without adding it to the dependency array (which would cause infinite loops).
+  const selectedResidueIdRef = useRef(selectedResidueId);
+  selectedResidueIdRef.current = selectedResidueId;
+
   useEffect(() => {
     if (!viewerRef.current || !structureRef || !selectedChainId) return;
     try {
@@ -44,17 +53,19 @@ export function useUpdateResidueInfo(
       // Get residue info from molstar utility
       const { residueLabels, residueToAtomIds } = molstar.getResidueInfo(structureObj, selectedChainId);
       setResidueInfo({ residueLabels, residueToAtomIds });
-      // Auto-select first residue if none selected
-      if (!selectedResidueId && residueLabels.size > 0) {
+      // Reset selection when the current residue ID is not in the new chain.
+      // Also auto-select the first residue when nothing is selected.
+      const currentId = selectedResidueIdRef.current;
+      if (residueLabels.size > 0 && (!currentId || !residueLabels.has(currentId))) {
         setSelectedResidueId(Array.from(residueLabels.keys())[0] as string);
       }
-      if (label) {
-        // eslint-disable-next-line no-console
-        console.log(`[useUpdateResidueInfo][${label}] residueLabels:`, residueLabels);
-      }
+      // Debug logging disabled to avoid console spam; uncomment if needed:
+      // if (label) console.log(`[useUpdateResidueInfo][${label}] residueLabels:`, residueLabels);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.warn(`[useUpdateResidueInfo][${label}] failed:`, err);
     }
-  }, [viewerRef, structureRef, molstar, selectedChainId, setResidueInfo, selectedResidueId, setSelectedResidueId, label]);
+  // selectedResidueId intentionally omitted — accessed via ref to avoid loops
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [viewerRef, structureRef, molstar, selectedChainId, setResidueInfo, setSelectedResidueId, label]);
 }

--- a/src/utils/chain.test.ts
+++ b/src/utils/chain.test.ts
@@ -4,8 +4,8 @@
  * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
  * 
  * @author Andy Turner <agdturner@gmail.com>
- * @version 1.0.0
- * @lastModified 2026-04-24
+ * @version 1.0.1
+ * @lastModified 2026-06-22
  * @see https://github.com/ribocode-slola/ribocode1
  */
 import { vi } from 'vitest';
@@ -59,5 +59,121 @@ describe('getChainInfo', () => {
         } as any;
         const result = getChainInfo(structure);
         expect(result.chainLabels.get('C')).toBe('[auth C]');
+    });
+
+    it('deduplicates chains with the same auth_asym_id across units', () => {
+        const mockChains = {
+            _rowCount: 1,
+            auth_asym_id: { value: () => 'A' },
+            label_asym_id: { value: () => 'AA' },
+        };
+        const structure = {
+            units: [
+                { model: { atomicHierarchy: { chains: mockChains } } },
+                { model: { atomicHierarchy: { chains: mockChains } } }
+            ]
+        } as any;
+        const result = getChainInfo(structure);
+        expect(result.chainLabels.size).toBe(1);
+        expect(result.chainLabels.get('A')).toBe('AA [auth A]');
+    });
+});
+
+describe('getChainInfo with rpNameLookup enrichment', () => {
+    let originalWarn: any;
+    let originalLog: any;
+    beforeAll(() => {
+        originalWarn = console.warn;
+        originalLog = console.log;
+        console.warn = vi.fn();
+        console.log = vi.fn();
+    });
+    afterAll(() => {
+        console.warn = originalWarn;
+        console.log = originalLog;
+    });
+
+    function makeStructure(opts: {
+        authId: string;
+        labelId?: string;
+        entityId?: string;
+        structRef?: { entityId: string; accession: string }[];
+    }) {
+        const mockChains: any = {
+            _rowCount: 1,
+            auth_asym_id: { value: () => opts.authId },
+            label_asym_id: opts.labelId ? { value: () => opts.labelId } : undefined,
+        };
+        if (opts.entityId !== undefined) {
+            mockChains.label_entity_id = { value: () => opts.entityId };
+        }
+        const structRefRows = opts.structRef || [];
+        const model: any = {
+            atomicHierarchy: { chains: mockChains },
+            sourceData: opts.structRef
+                ? {
+                    data: {
+                        db: {
+                            struct_ref: {
+                                _rowCount: structRefRows.length,
+                                entity_id: { value: (i: number) => structRefRows[i]?.entityId },
+                                pdbx_db_accession: { value: (i: number) => structRefRows[i]?.accession }
+                            }
+                        }
+                    }
+                }
+                : undefined
+        };
+        return { units: [{ model }] } as any;
+    }
+
+    it('uses gene family name when UniProt resolves via struct_ref', () => {
+        const rpNameLookup = new Map([['P61247', 'eS1']]);
+        const structure = makeStructure({
+            authId: 'A',
+            labelId: 'AA',
+            entityId: '1',
+            structRef: [{ entityId: '1', accession: 'P61247' }]
+        });
+        const result = getChainInfo(structure, rpNameLookup);
+        expect(result.chainLabels.get('A')).toBe('eS1 [AA]');
+    });
+
+    it('falls back to default label when UniProt is not in rpNameLookup', () => {
+        const rpNameLookup = new Map([['P99999', 'someFamily']]); // P61247 not present
+        const structure = makeStructure({
+            authId: 'A',
+            labelId: 'AA',
+            entityId: '1',
+            structRef: [{ entityId: '1', accession: 'P61247' }]
+        });
+        const result = getChainInfo(structure, rpNameLookup);
+        expect(result.chainLabels.get('A')).toBe('AA [auth A]');
+    });
+
+    it('falls back to default label when struct_ref is absent', () => {
+        const rpNameLookup = new Map([['P61247', 'eS1']]);
+        const structure = makeStructure({ authId: 'B', labelId: 'BB' }); // no entityId, no structRef
+        const result = getChainInfo(structure, rpNameLookup);
+        expect(result.chainLabels.get('B')).toBe('BB [auth B]');
+    });
+
+    it('falls back to authId in brackets when labelId is missing and no family found', () => {
+        const rpNameLookup = new Map<string, string>();
+        const structure = makeStructure({ authId: 'C' }); // no labelId, no structRef
+        const result = getChainInfo(structure, rpNameLookup);
+        expect(result.chainLabels.get('C')).toBe('[auth C]');
+    });
+
+    it('uses authId in family label when labelId is absent', () => {
+        const rpNameLookup = new Map([['P61247', 'eS1']]);
+        const structure = makeStructure({
+            authId: 'A',
+            // no labelId
+            entityId: '1',
+            structRef: [{ entityId: '1', accession: 'P61247' }]
+        });
+        const result = getChainInfo(structure, rpNameLookup);
+        expect(result.chainLabels.get('A')).toBe('eS1 [A]');
     });
 });

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -4,36 +4,79 @@
  * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
  * 
  * @author Andy Turner <agdturner@gmail.com>
- * @version 1.0.0
- * @lastModified 2026-04-24
+ * @version 1.0.1
+ * @lastModified 2026-06-22
  * @see https://github.com/ribocode-slola/ribocode1
  */
 import { Structure } from 'molstar/lib/mol-model/structure';
+import { buildEntityToUniprotMap } from './rpNameTable';
 
 /**
  * Extracts chain IDs and labels from a Mol* Structure object.
+ *
+ * When `rpNameLookup` is provided the function attempts to resolve a gene
+ * family name (e.g. "uS2", "eS1") for each chain by:
+ *   1. Reading the `_struct_ref.pdbx_db_accession` mmCIF table from the model
+ *      to map entity IDs → UniProt accession codes.
+ *   2. Looking up each UniProt accession in `rpNameLookup`.
+ * If a family name is found the label becomes `<family> [<labelId>]`;
+ * otherwise it falls back to `<labelId> [auth <authId>]`.
+ *
  * @param structure The Mol* Structure object.
- * @returns An object containing a Map of chain IDs to their labels.
+ * @param rpNameLookup Optional Map<uniprotCode, familyName> from parseRpNameTable().
+ * @returns An object containing a Map of auth chain IDs to their display labels.
  */
-export function getChainInfo(structure: Structure):
- { chainLabels: Map<string, string> } {
+export function getChainInfo(
+    structure: Structure,
+    rpNameLookup?: Map<string, string>
+): { chainLabels: Map<string, string> } {
     const chainLabels: Map<string, string> = new Map();
     const units = structure.units;
     if (!units || units.length === 0) {
         console.warn('No units found in structure.');
         return { chainLabels };
     }
-    //console.log('Structure units:', structure.units);
     units.forEach(unit => {
-        const chains = unit.model.atomicHierarchy.chains;
+        // Only process atomic units
+        if ((unit as any).kind !== undefined && (unit as any).kind !== 0) return;
+        const model = (unit as any).model;
+        if (!model) return;
+        const chains = model.atomicHierarchy?.chains;
+        if (!chains) return;
         const { auth_asym_id, label_asym_id } = chains;
+
+        // Build entity → UniProt map once per model (if lookup provided)
+        let entityToUniprot: Map<string, string> | undefined;
+        if (rpNameLookup) {
+            entityToUniprot = buildEntityToUniprotMap(model);
+        }
+
         for (let i = 0; i < chains._rowCount; i++) {
-            const authId = auth_asym_id.value(i);
-            const labelId = label_asym_id?.value ? label_asym_id.value(i) : '';
-            const label = labelId ? `${labelId} [auth ${authId}]` : `[auth ${authId}]`;
+            const authId: string = auth_asym_id.value(i);
+            if (chainLabels.has(authId)) continue; // deduplicate across units
+
+            const labelId: string = label_asym_id?.value ? label_asym_id.value(i) : '';
+
+            // Attempt to resolve gene family name via UniProt
+            let familyName: string | undefined;
+            if (rpNameLookup && entityToUniprot) {
+                const entityId = chains.label_entity_id?.value
+                    ? String(chains.label_entity_id.value(i))
+                    : undefined;
+                const uniprot = entityId ? entityToUniprot.get(entityId) : undefined;
+                if (uniprot) {
+                    familyName = rpNameLookup.get(uniprot);
+                }
+            }
+
+            let label: string;
+            if (familyName) {
+                label = `${familyName} [${labelId || authId}]`;
+            } else {
+                label = labelId ? `${labelId} [auth ${authId}]` : `[auth ${authId}]`;
+            }
             chainLabels.set(authId, label);
         }
     });
-    console.log('chainLabels', chainLabels);
     return { chainLabels };
 }

--- a/src/utils/residue.test.ts
+++ b/src/utils/residue.test.ts
@@ -90,7 +90,5 @@ describe('getResidueInfo', () => {
             insCode: ''
         });
         expect(result.residueToAtomIds['10']).toEqual(['5']);
-        expect(console.info).toHaveBeenCalledWith('[getResidueInfo] residueLabels:', expect.any(Map));
-        expect(console.info).toHaveBeenCalledWith('[getResidueInfo] residueToAtomIds:', expect.any(Object));
     });
 });

--- a/src/utils/residue.ts
+++ b/src/utils/residue.ts
@@ -149,8 +149,9 @@ export function getResidueInfo(
             });
         }
     }
-    console.info('[getResidueInfo] residueLabels:', residueLabels);
-    console.info('[getResidueInfo] residueToAtomIds:', residueToAtomIds);
+    // Debug logging disabled to avoid console spam; uncomment if needed:
+    // console.info('[getResidueInfo] residueLabels:', residueLabels);
+    // console.info('[getResidueInfo] residueToAtomIds:', residueToAtomIds);
     return {
         residueLabels: residueLabels,
         residueToAtomIds: residueToAtomIds

--- a/src/utils/rpNameTable.test.ts
+++ b/src/utils/rpNameTable.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Test suite for rpNameTable utility functions.
+ *
+ * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Andy Turner <agdturner@gmail.com>
+ * @version 1.0.0
+ * @lastModified 2026-06-22
+ * @see https://github.com/ribocode-slola/ribocode1
+ */
+import { parseRpNameTable, buildEntityToUniprotMap } from './rpNameTable';
+
+describe('parseRpNameTable', () => {
+    const HEADER = 'family,human_old_name,yeast_old_name,arabdidopsis_homologs,drosophila_homologs,human_homologs,yeast_homologs';
+
+    it('returns an empty map for empty input', () => {
+        expect(parseRpNameTable('').size).toBe(0);
+    });
+
+    it('returns an empty map for header-only input', () => {
+        expect(parseRpNameTable(HEADER).size).toBe(0);
+    });
+
+    it('maps a single human UniProt code to its family name', () => {
+        const csv = [HEADER, 'eS1,S1,S3A,,,,P61247'].join('\n');
+        const lookup = parseRpNameTable(csv);
+        expect(lookup.get('P61247')).toBe('eS1');
+    });
+
+    it('maps multiple semicolon-separated UniProt codes in one column', () => {
+        const csv = [HEADER, 'uS2,S0,SA,,,P08865;A0A0C4DG17,P32905'].join('\n');
+        const lookup = parseRpNameTable(csv);
+        expect(lookup.get('P08865')).toBe('uS2');
+        expect(lookup.get('A0A0C4DG17')).toBe('uS2');
+        expect(lookup.get('P32905')).toBe('uS2');
+    });
+
+    it('maps codes across all species columns (cols 3–6)', () => {
+        const csv = [
+            HEADER,
+            'uS3,S3,S3,Q9M339,Q06559,P23396,A0A6A5Q3Q1'
+        ].join('\n');
+        const lookup = parseRpNameTable(csv);
+        // arabidopsis (col 3)
+        expect(lookup.get('Q9M339')).toBe('uS3');
+        // drosophila (col 4)
+        expect(lookup.get('Q06559')).toBe('uS3');
+        // human (col 5)
+        expect(lookup.get('P23396')).toBe('uS3');
+        // yeast (col 6)
+        expect(lookup.get('A0A6A5Q3Q1')).toBe('uS3');
+    });
+
+    it('ignores blank lines in the CSV', () => {
+        const csv = [HEADER, '', 'eS1,S1,S3A,,,,P61247', ''].join('\n');
+        const lookup = parseRpNameTable(csv);
+        expect(lookup.get('P61247')).toBe('eS1');
+        expect(lookup.size).toBe(1);
+    });
+
+    it('handles multiple rows correctly', () => {
+        const csv = [
+            HEADER,
+            'eS1,S1,S3A,,,,P61247',
+            'uS2,S0,SA,,,P08865,P32905'
+        ].join('\n');
+        const lookup = parseRpNameTable(csv);
+        expect(lookup.get('P61247')).toBe('eS1');
+        expect(lookup.get('P08865')).toBe('uS2');
+        expect(lookup.get('P32905')).toBe('uS2');
+    });
+
+    it('trims whitespace from UniProt codes', () => {
+        const csv = [HEADER, 'eS1,S1,S3A,,,  P61247 ;D6RG13  ,'].join('\n');
+        const lookup = parseRpNameTable(csv);
+        expect(lookup.get('P61247')).toBe('eS1');
+        expect(lookup.get('D6RG13')).toBe('eS1');
+    });
+
+    it('does not map old names (columns 1 and 2) to family', () => {
+        const csv = [HEADER, 'eS1,S1,S3A,,,,P61247'].join('\n');
+        const lookup = parseRpNameTable(csv);
+        expect(lookup.has('S1')).toBe(false);
+        expect(lookup.has('S3A')).toBe(false);
+    });
+
+    it('parses a realistic excerpt from the actual CSV', () => {
+        const csv = [
+            HEADER,
+            'eS1,S1,S3A,Q42262;Q9CAV0,P55830,P61247;D6RG13;D6RGE0,A0A6A5PRY4;P33442',
+            'uS2,S0,SA,B9DG17;Q08682,P38979,P08865;A0A0C4DG17,P32905;P46654'
+        ].join('\n');
+        const lookup = parseRpNameTable(csv);
+        expect(lookup.get('Q42262')).toBe('eS1');
+        expect(lookup.get('P55830')).toBe('eS1');
+        expect(lookup.get('D6RGE0')).toBe('eS1');
+        expect(lookup.get('P33442')).toBe('eS1');
+        expect(lookup.get('B9DG17')).toBe('uS2');
+        expect(lookup.get('P38979')).toBe('uS2');
+        expect(lookup.get('P46654')).toBe('uS2');
+    });
+});
+
+describe('buildEntityToUniprotMap', () => {
+    it('returns an empty map when model is null', () => {
+        expect(buildEntityToUniprotMap(null).size).toBe(0);
+    });
+
+    it('returns an empty map when sourceData is absent', () => {
+        expect(buildEntityToUniprotMap({}).size).toBe(0);
+    });
+
+    it('returns an empty map when struct_ref is absent', () => {
+        const model = { sourceData: { data: { db: {} } } };
+        expect(buildEntityToUniprotMap(model).size).toBe(0);
+    });
+
+    it('maps entity IDs to UniProt accessions', () => {
+        const model = {
+            sourceData: {
+                data: {
+                    db: {
+                        struct_ref: {
+                            _rowCount: 2,
+                            entity_id: { value: (i: number) => ['1', '2'][i] },
+                            pdbx_db_accession: { value: (i: number) => ['P61247', 'P08865'][i] }
+                        }
+                    }
+                }
+            }
+        };
+        const map = buildEntityToUniprotMap(model);
+        expect(map.get('1')).toBe('P61247');
+        expect(map.get('2')).toBe('P08865');
+    });
+
+    it('trims whitespace from accession values', () => {
+        const model = {
+            sourceData: {
+                data: {
+                    db: {
+                        struct_ref: {
+                            _rowCount: 1,
+                            entity_id: { value: () => '1' },
+                            pdbx_db_accession: { value: () => '  P61247  ' }
+                        }
+                    }
+                }
+            }
+        };
+        const map = buildEntityToUniprotMap(model);
+        expect(map.get('1')).toBe('P61247');
+    });
+
+    it('returns an empty map when struct_ref throws', () => {
+        const model = {
+            sourceData: {
+                data: {
+                    db: {
+                        struct_ref: {
+                            get _rowCount() { throw new Error('oops'); }
+                        }
+                    }
+                }
+            }
+        };
+        expect(buildEntityToUniprotMap(model).size).toBe(0);
+    });
+});

--- a/src/utils/rpNameTable.ts
+++ b/src/utils/rpNameTable.ts
@@ -1,0 +1,88 @@
+/**
+ * Utility functions for parsing and using the RP_name_table_uniprot.csv data file.
+ *
+ * The CSV maps gene family names (e.g. uS2, eS1) to UniProt accession codes for
+ * multiple species (arabidopsis, drosophila, human, yeast). This lookup is used to
+ * enrich chain labels in the viewer so users see meaningful protein names instead
+ * of raw mmCIF identifiers.
+ *
+ * Expected CSV format:
+ *   family,human_old_name,yeast_old_name,arabdidopsis_homologs,drosophila_homologs,human_homologs,yeast_homologs
+ *   eS1,S1,S3A,Q42262;Q9CAV0,P55830,P61247;D6RG13,A0A6A5PRY4;P33442
+ *
+ * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
+ *
+ * @author Andy Turner <agdturner@gmail.com>
+ * @version 1.0.0
+ * @lastModified 2026-06-22
+ * @see https://github.com/ribocode-slola/ribocode1
+ */
+
+/**
+ * Column indices in the CSV that hold semicolon-separated UniProt accession codes.
+ * 0=family, 1=human_old_name, 2=yeast_old_name, 3=arabidopsis, 4=drosophila, 5=human, 6=yeast
+ */
+const UNIPROT_COL_INDICES = [3, 4, 5, 6];
+
+/**
+ * Parses the RP_name_table_uniprot.csv content into a lookup map.
+ *
+ * Each UniProt accession found in the arabidopsis, drosophila, human, or yeast
+ * homolog columns is mapped to the gene family name in column 0 (e.g. "eS1", "uS2").
+ *
+ * @param csvText - Raw text content of RP_name_table_uniprot.csv.
+ * @returns Map from UniProt accession code → gene family name.
+ */
+export function parseRpNameTable(csvText: string): Map<string, string> {
+    const lookup = new Map<string, string>();
+    const lines = csvText.split('\n');
+    // Skip header row (line 0)
+    for (let i = 1; i < lines.length; i++) {
+        const line = lines[i].trim();
+        if (!line) continue;
+        const cols = line.split(',');
+        const family = cols[0]?.trim();
+        if (!family) continue;
+        for (const ci of UNIPROT_COL_INDICES) {
+            const cellValue = cols[ci] || '';
+            const codes = cellValue.split(';');
+            for (const code of codes) {
+                const c = code.trim();
+                if (c) {
+                    lookup.set(c, family);
+                }
+            }
+        }
+    }
+    return lookup;
+}
+
+/**
+ * Builds a map from entity ID to UniProt accession from a Mol* model's struct_ref data.
+ *
+ * Reads the `_struct_ref` mmCIF category (accessible via `model.sourceData.data.db.struct_ref`)
+ * and returns a Map<entityId, uniprotAccession>.
+ *
+ * Returns an empty map if the data is not available (e.g. in tests or non-mmCIF sources).
+ *
+ * @param model - A Mol* model object.
+ * @returns Map from entity ID string → UniProt accession string.
+ */
+export function buildEntityToUniprotMap(model: any): Map<string, string> {
+    const entityToUniprot = new Map<string, string>();
+    try {
+        const structRef = model?.sourceData?.data?.db?.struct_ref;
+        if (!structRef) return entityToUniprot;
+        const rowCount: number = structRef._rowCount ?? 0;
+        for (let r = 0; r < rowCount; r++) {
+            const entityId = structRef.entity_id?.value?.(r);
+            const accession = structRef.pdbx_db_accession?.value?.(r);
+            if (entityId != null && accession) {
+                entityToUniprot.set(String(entityId), String(accession).trim());
+            }
+        }
+    } catch {
+        // Gracefully degrade — no UniProt data available
+    }
+    return entityToUniprot;
+}

--- a/src/utils/structure.test.ts
+++ b/src/utils/structure.test.ts
@@ -73,12 +73,38 @@ describe('structure', () => {
     describe('focusLociOnChain', () => {
         it('calls camera.focusLoci if loci is found', () => {
             focusLociOnChain(plugin, structureRef, chainId, undefined, () => lociObj);
-            expect(plugin.managers.camera.focusLoci).toHaveBeenCalledWith(lociObj);
+            expect(plugin.managers.camera.focusLoci).toHaveBeenCalledWith(lociObj, undefined);
         });
         it('does not call camera.focusLoci if loci is null', () => {
             (plugin.managers.camera.focusLoci as ReturnType<typeof vi.fn>).mockClear();
             focusLociOnChain(plugin, structureRef, chainId, undefined, () => null);
             expect(plugin.managers.camera.focusLoci).not.toHaveBeenCalled();
+        });
+        it('passes extraRadius and minRadius as focus options when both are provided', () => {
+            (plugin.managers.camera.focusLoci as ReturnType<typeof vi.fn>).mockClear();
+            focusLociOnChain(plugin, structureRef, chainId, undefined, () => lociObj, 20, 16);
+            expect(plugin.managers.camera.focusLoci).toHaveBeenCalledWith(
+                lociObj,
+                { extraRadius: 20, minRadius: 16 }
+            );
+        });
+        it('passes no focus options when only one zoom param is provided', () => {
+            (plugin.managers.camera.focusLoci as ReturnType<typeof vi.fn>).mockClear();
+            // Only zoomExtraRadius provided → no options object
+            focusLociOnChain(plugin, structureRef, chainId, undefined, () => lociObj, 20, undefined);
+            expect(plugin.managers.camera.focusLoci).toHaveBeenCalledWith(lociObj, undefined);
+        });
+        it('also focuses sync plugin with same options when syncPlugin is provided', () => {
+            const syncPlugin = {
+                managers: { camera: { focusLoci: vi.fn() } }
+            } as any;
+            focusLociOnChain(plugin, structureRef, chainId, syncPlugin, () => lociObj, 10, 5);
+            expect(plugin.managers.camera.focusLoci).toHaveBeenCalledWith(
+                lociObj, { extraRadius: 10, minRadius: 5 }
+            );
+            expect(syncPlugin.managers.camera.focusLoci).toHaveBeenCalledWith(
+                lociObj, { extraRadius: 10, minRadius: 5 }
+            );
         });
     });
 

--- a/src/utils/structure.ts
+++ b/src/utils/structure.ts
@@ -62,19 +62,25 @@ export function getChainLoci(plugin: PluginUIContext, structureRef: string, chai
 
 /**
  * Focus the camera on a chain loci, with optional sync to another plugin.
+ * Accepts zoom options for extraRadius and minRadius (same as focusLociOnResidue).
  */
 export function focusLociOnChain(
     plugin: PluginUIContext,
     structureRef: string,
     chainId: string,
     syncPlugin?: PluginUIContext,
-    getChainLociFn: (plugin: PluginUIContext, structureRef: string, chainId: string) => any = getChainLoci
+    getChainLociFn: (plugin: PluginUIContext, structureRef: string, chainId: string) => any = getChainLoci,
+    zoomExtraRadius?: number,
+    zoomMinRadius?: number
 ) {
     const loci = getChainLociFn(plugin, structureRef, chainId);
     if (!loci) return;
-    plugin.managers.camera.focusLoci(loci);
+    const focusOptions = (zoomExtraRadius !== undefined && zoomMinRadius !== undefined)
+        ? { extraRadius: zoomExtraRadius, minRadius: zoomMinRadius }
+        : undefined;
+    plugin.managers.camera.focusLoci(loci, focusOptions);
     if (syncPlugin) {
-        syncPlugin.managers.camera.focusLoci(loci);
+        syncPlugin.managers.camera.focusLoci(loci, focusOptions);
     }
 }
 

--- a/src/utils/viewerHelpers.test.ts
+++ b/src/utils/viewerHelpers.test.ts
@@ -4,8 +4,8 @@
  * Copyright (c) 2024-now Ribocode contributors, licensed under MIT, See LICENSE file for more info.
  * 
  * @author Andy Turner <agdturner@gmail.com>
- * @version 1.0.0
- * @lastModified 2026-04-24
+ * @version 1.0.1
+ * @lastModified 2026-06-22
  * @see https://github.com/ribocode-slola/ribocode1
  */
 import { vi } from 'vitest';
@@ -72,10 +72,43 @@ describe('viewerHelpers', () => {
 
     await handler.handleButtonClick();
 
+    // zoomExtraRadius/zoomMinRadius not supplied → undefined; syncPlugin passed
     expect(focusLociOnChain).toHaveBeenCalledWith(
       pluginRef.current,
       'struct-a',
-      'A'
+      'A',
+      syncPluginRef.current,
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+
+  it('passes zoomExtraRadius and zoomMinRadius to chain zoom handler', async () => {
+    const pluginRef = { current: { id: 'plugin-a' } };
+    const handler = createZoomHandler(
+      pluginRef as any,
+      'struct-a',
+      'chain-test',
+      'B',
+      false,
+      undefined,
+      undefined,
+      undefined,
+      20,
+      16
+    );
+
+    await handler.handleButtonClick();
+
+    expect(focusLociOnChain).toHaveBeenCalledWith(
+      pluginRef.current,
+      'struct-a',
+      'B',
+      undefined,
+      undefined,
+      20,
+      16
     );
   });
 
@@ -106,6 +139,34 @@ describe('viewerHelpers', () => {
       syncPluginRef.current,
       5,
       2
+    );
+  });
+
+  it('passes zoomExtraRadius/minRadius for residue zoom when sync is disabled', async () => {
+    const pluginRef = { current: { id: 'plugin-a' } };
+    const handler = makeZoomHandler({
+      pluginRef: pluginRef as any,
+      structureRef: 'struct-a',
+      property: 'residue-test',
+      chainId: 'B',
+      sync: false,
+      residueId: '10',
+      insCode: '',
+      zoomExtraRadius: 24,
+      zoomMinRadius: 12,
+    });
+
+    await handler.handleButtonClick();
+
+    expect(focusLociOnResidue).toHaveBeenCalledWith(
+      pluginRef.current,
+      'struct-a',
+      'B',
+      '10',
+      '',
+      undefined,
+      24,
+      12
     );
   });
 });

--- a/src/utils/viewerHelpers.ts
+++ b/src/utils/viewerHelpers.ts
@@ -49,7 +49,11 @@ export function createZoomHandler(
                 focusLociOnChain(
                     plugin,
                     structureRef,
-                    chainId
+                    chainId,
+                    sync && syncPluginRef?.current ? syncPluginRef.current : undefined,
+                    undefined,        // use default getChainLociFn
+                    zoomExtraRadius,
+                    zoomMinRadius
                 );
             } else if (property === 'residue-test') {
                 focusLociOnResidue(


### PR DESCRIPTION
v0.7.3 fixes residue zoom option propagation so General Controls values (extraRadius/minRadius) are applied in Mol* focus operations.
Adds regression test coverage for residue zoom option forwarding and keeps recent chain/residue selection reliability improvements, including RP_name_table_uniprot.csv-based chain label enhancements.