### PR TITLE
v0.7.4 — Session restore fidelity improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v0.7.4] - 2026-06-22
+- Extended session save/load to persist and restore UI state exactly, including `Residue Zoom` (`extraRadius`, `minRadius`), subunit/chain/residue selections for both columns, sync state, and active viewer.
+- Added camera snapshot persistence for both viewers so orientation and zoom radius are restored on session load.
+- Added integration coverage for `uiState` save/restore behavior, including regression checks for sync and camera state restoration.
+
 ## [v0.7.3] - 2026-06-22
 - Fixed residue zoom wiring in `App.tsx` so `Residue Zoom extraRadius` and `minRadius` are passed through to Mol* focus calls.
 - Added regression coverage for residue zoom option forwarding in `viewerHelpers` tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ribocode1",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ribocode1",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ribocode1",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/App.integration.test.tsx
+++ b/src/App.integration.test.tsx
@@ -24,6 +24,13 @@ vi.mock('./hooks/useSessionLoadModal', () => ({
   }),
 }));
 
+vi.mock('./hooks/useSessionSave', () => ({
+  useSessionSave: vi.fn((getSessionState: any) => {
+    (globalThis as any).__getSessionState = getSessionState;
+    return vi.fn();
+  }),
+}));
+
 vi.mock('molstar/lib/mol-plugin/commands', () => ({
   PluginCommands: {
     State: {
@@ -70,7 +77,13 @@ vi.mock('./hooks/useMolstarViewer', () => ({
       setRepIdMap: vi.fn((key: string, map: Record<string, string>) => {
         repIdMap[key] = map;
       }),
-      getResidueInfo: vi.fn().mockReturnValue({ residueLabels: new Map(), residueToAtomIds: {} }),
+      getResidueInfo: vi.fn().mockReturnValue({
+        residueLabels: new Map([
+          ['10', { id: '10', name: 'GLY 10', compId: 'GLY', seqNumber: 10, insCode: '' }],
+          ['20', { id: '20', name: 'ALA 20', compId: 'ALA', seqNumber: 20, insCode: '' }],
+        ]),
+        residueToAtomIds: { '10': ['1'], '20': ['2'] },
+      }),
     };
     allInstances.push(instance);
     return instance;
@@ -114,6 +127,19 @@ vi.mock('molstar/lib/extensions/ribocode/structure', () => {
 // Mock MolstarContainer to always render a stub and trigger viewer loaded state
 vi.mock('./components/MolstarContainer', () => {
   const React = require('react');
+  const createMockCamera = () => ({
+    state: { mode: 'perspective' },
+    stateChanged: {
+      subscribe: vi.fn(() => ({ unsubscribe: vi.fn() })),
+    },
+    getSnapshot: vi.fn(() => ({
+      position: [1, 2, 3],
+      target: [4, 5, 6],
+      up: [0, 1, 0],
+      radius: 10,
+    })),
+    setState: vi.fn(),
+  });
   const buildStructure = (ref: string) => ({
     cell: {
       transform: { ref },
@@ -141,7 +167,10 @@ vi.mock('./components/MolstarContainer', () => {
       },
     },
     state: { data: {} },
-    canvas3d: { requestDraw: () => {} },
+    canvas3d: {
+      requestDraw: vi.fn(),
+      camera: createMockCamera(),
+    },
   });
   const mockPluginA = buildPlugin();
   const mockPluginB = buildPlugin();
@@ -370,6 +399,107 @@ describe('App integration: AlignedTo and Aligned loading', () => {
     const alignedCalls = loadMoleculeFileToViewerMock.mock.calls.filter((args: any[]) => args[2] === false);
     expect(alignedCalls.length).toBeGreaterThan(0);
     expect(alignedCalls[0][4]).toEqual({ rows: [1] });
+  });
+
+  it('includes zoom and selection UI state in saved session payload', async () => {
+    render(<App />);
+    await waitFor(() => expect(screen.getByRole('banner')).toBeInTheDocument());
+
+    const alignedToInput = document.getElementById('viewer-column-A-alignedto-file-input') as HTMLInputElement | null;
+    const alignedInput = document.getElementById('viewer-column-B-aligned-file-input') as HTMLInputElement | null;
+    const alignedLoadBtn = document.getElementById('viewer-column-B-aligned-load-btn') as HTMLButtonElement | null;
+    expect(alignedToInput).toBeInTheDocument();
+    expect(alignedInput).toBeInTheDocument();
+    expect(alignedLoadBtn).toBeInTheDocument();
+
+    fireEvent.change(alignedToInput!, { target: { files: [loadTestFile('4ug0.cif')] } });
+    await waitFor(() => {
+      expect(document.getElementById('viewer-column-B-aligned-load-btn')).not.toBeDisabled();
+    }, { timeout: 5000 });
+    fireEvent.change(alignedInput!, { target: { files: [loadTestFile('6xu8.cif')] } });
+    fireEvent.click(alignedLoadBtn!);
+
+    await waitFor(() => {
+      expect(document.getElementById('viewer-column-A-alignedto-subunit-select')).toBeInTheDocument();
+      expect(document.getElementById('viewer-column-B-aligned-subunit-select')).toBeInTheDocument();
+      expect(document.getElementById('generalcontrols-sync-select')).toBeInTheDocument();
+    }, { timeout: 5000 });
+
+    fireEvent.change(document.getElementById('generalcontrols-zoom-extra-radius') as HTMLInputElement, { target: { value: '24' } });
+    fireEvent.change(document.getElementById('generalcontrols-zoom-min-radius') as HTMLInputElement, { target: { value: '12' } });
+    fireEvent.change(document.getElementById('generalcontrols-sync-select') as HTMLSelectElement, { target: { value: 'On' } });
+    fireEvent.change(document.getElementById('viewer-column-A-alignedto-subunit-select') as HTMLSelectElement, { target: { value: 'Large' } });
+    fireEvent.change(document.getElementById('viewer-column-B-aligned-subunit-select') as HTMLSelectElement, { target: { value: 'Small' } });
+
+    const getSessionState = (globalThis as any).__getSessionState as (() => any) | undefined;
+    expect(getSessionState).toBeDefined();
+    const session = getSessionState!();
+
+    expect(session.uiState.zoom).toEqual({ extraRadius: 24, minRadius: 12 });
+    expect(session.uiState.syncEnabled).toBe(true);
+    expect(session.uiState.selections.alignedTo).toEqual(expect.objectContaining({
+      subunit: 'Large',
+    }));
+    expect(session.uiState.selections.aligned).toEqual(expect.objectContaining({
+      subunit: 'Small',
+    }));
+    expect(session.uiState.cameraSnapshots.viewerA).toEqual(expect.objectContaining({ radius: 10 }));
+    expect(session.uiState.cameraSnapshots.viewerB).toEqual(expect.objectContaining({ radius: 10 }));
+  });
+
+  it('restores zoom, selectors, and camera snapshot from session uiState', async () => {
+    render(<App />);
+    await waitFor(() => expect(screen.getByRole('banner')).toBeInTheDocument());
+
+    const onSessionLoaded = (globalThis as any).__onSessionLoaded as ((session: any, files: Record<string, File>) => Promise<void>) | undefined;
+    expect(onSessionLoaded).toBeDefined();
+
+    const session = {
+      viewerA: { moleculeAlignedTo: { filename: '4ug0.cif' } },
+      viewerB: { moleculeAligned: { filename: '6xu8.cif' } },
+      uiState: {
+        zoom: { extraRadius: 31, minRadius: 14 },
+        syncEnabled: true,
+        selections: {
+          alignedTo: { subunit: 'Large', chainId: 'A', residueId: '10' },
+          aligned: { subunit: 'Small', chainId: 'B', residueId: '20' },
+        },
+        cameraSnapshots: {
+          viewerA: { position: [10, 11, 12], target: [1, 2, 3], up: [0, 1, 0], radius: 42 },
+          viewerB: { position: [20, 21, 22], target: [4, 5, 6], up: [0, 1, 0], radius: 84 },
+        }
+      }
+    };
+    const files = {
+      '4ug0.cif': loadTestFile('4ug0.cif'),
+      '6xu8.cif': loadTestFile('6xu8.cif'),
+    };
+
+    const pluginA = (globalThis as any).__mockPluginA;
+    const pluginB = (globalThis as any).__mockPluginB;
+    pluginA.canvas3d.camera.setState.mockClear();
+    pluginB.canvas3d.camera.setState.mockClear();
+
+    await onSessionLoaded!(session, files);
+
+    await waitFor(() => {
+      expect((document.getElementById('generalcontrols-zoom-extra-radius') as HTMLInputElement).value).toBe('31');
+      expect((document.getElementById('generalcontrols-zoom-min-radius') as HTMLInputElement).value).toBe('14');
+      expect((document.getElementById('generalcontrols-sync-select') as HTMLSelectElement).value).toBe('On');
+    }, { timeout: 5000 });
+
+    expect(pluginA.canvas3d.camera.setState).toHaveBeenCalledWith(expect.objectContaining({
+      position: [10, 11, 12],
+      target: [1, 2, 3],
+      up: [0, 1, 0],
+      radius: 42,
+    }));
+    expect(pluginB.canvas3d.camera.setState).toHaveBeenCalledWith(expect.objectContaining({
+      position: [20, 21, 22],
+      target: [4, 5, 6],
+      up: [0, 1, 0],
+      radius: 84,
+    }));
   });
 
   it('restores saved additional representations on session load (regression)', async () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,6 +71,38 @@ interface SessionRepresentationSpec {
     visible: boolean;
 }
 
+interface SerializableCameraSnapshot {
+    position: [number, number, number];
+    target: [number, number, number];
+    up: [number, number, number];
+    radius: number;
+}
+
+interface SessionUiState {
+    zoom?: {
+        extraRadius: number;
+        minRadius: number;
+    };
+    selections?: {
+        alignedTo?: {
+            subunit?: string;
+            chainId?: string;
+            residueId?: string;
+        };
+        aligned?: {
+            subunit?: string;
+            chainId?: string;
+            residueId?: string;
+        };
+    };
+    syncEnabled?: boolean;
+    activeViewer?: ViewerKey;
+    cameraSnapshots?: {
+        viewerA?: SerializableCameraSnapshot;
+        viewerB?: SerializableCameraSnapshot;
+    };
+}
+
 const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
 
     // Store Files and filenames for aligned and alignedTo molecule reloads.
@@ -227,6 +259,39 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
         console.log(`[serializeRepresentationsForMode] ${mode}: captured ${rawReps.length} reps, normalized to ${normalized.length}:`, normalized.map(r => `${r.type}(${r.visible ? 'visible' : 'hidden'})`).join(', '));
         return normalized;
     }, [normalizeSessionRepresentation]);
+
+    const getSerializableCameraSnapshot = useCallback((viewerRef: React.RefObject<PluginUIContext | null>): SerializableCameraSnapshot | undefined => {
+        const snapshot = viewerRef.current?.canvas3d?.camera?.getSnapshot?.();
+        if (!snapshot) return undefined;
+        const toTuple3 = (value: any): [number, number, number] | null => {
+            if (!value || value.length < 3) return null;
+            const x = Number(value[0]);
+            const y = Number(value[1]);
+            const z = Number(value[2]);
+            if (!Number.isFinite(x) || !Number.isFinite(y) || !Number.isFinite(z)) return null;
+            return [x, y, z];
+        };
+        const position = toTuple3(snapshot.position);
+        const target = toTuple3(snapshot.target);
+        const up = toTuple3(snapshot.up);
+        const radius = Number(snapshot.radius);
+        if (!position || !target || !up || !Number.isFinite(radius)) return undefined;
+        return { position, target, up, radius };
+    }, []);
+
+    const applySerializableCameraSnapshot = useCallback((viewerRef: React.RefObject<PluginUIContext | null>, snapshot?: SerializableCameraSnapshot) => {
+        if (!snapshot) return;
+        const camera = viewerRef.current?.canvas3d?.camera;
+        if (!camera || typeof camera.setState !== 'function') return;
+        camera.setState({
+            ...camera.state,
+            position: [...snapshot.position] as any,
+            target: [...snapshot.target] as any,
+            up: [...snapshot.up] as any,
+            radius: snapshot.radius,
+        });
+        viewerRef.current?.canvas3d?.requestDraw?.();
+    }, []);
 
     const waitForRepresentationRef = useCallback(async (
         molstar: ReturnType<typeof useMolstarViewer>,
@@ -936,7 +1001,30 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
                 }
                 : null,
         },
-        // Add more serializable state as needed
+        uiState: {
+            zoom: {
+                extraRadius: zoomExtraRadius,
+                minRadius: zoomMinRadius,
+            },
+            selections: {
+                alignedTo: {
+                    subunit: selectedSubunitAlignedTo,
+                    chainId: selectedChainIdAlignedTo,
+                    residueId: selectedResidueIdAlignedTo,
+                },
+                aligned: {
+                    subunit: selectedSubunitAligned,
+                    chainId: selectedChainIdAligned,
+                    residueId: selectedResidueIdAligned,
+                },
+            },
+            syncEnabled,
+            activeViewer,
+            cameraSnapshots: {
+                viewerA: getSerializableCameraSnapshot(viewerA.ref),
+                viewerB: getSerializableCameraSnapshot(viewerB.ref),
+            },
+        } as SessionUiState,
     }));
 
     const handleSaveSessionAll = useSessionSaveAll(
@@ -973,6 +1061,30 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
                     }
                     : null,
             },
+            uiState: {
+                zoom: {
+                    extraRadius: zoomExtraRadius,
+                    minRadius: zoomMinRadius,
+                },
+                selections: {
+                    alignedTo: {
+                        subunit: selectedSubunitAlignedTo,
+                        chainId: selectedChainIdAlignedTo,
+                        residueId: selectedResidueIdAlignedTo,
+                    },
+                    aligned: {
+                        subunit: selectedSubunitAligned,
+                        chainId: selectedChainIdAligned,
+                        residueId: selectedResidueIdAligned,
+                    },
+                },
+                syncEnabled,
+                activeViewer,
+                cameraSnapshots: {
+                    viewerA: getSerializableCameraSnapshot(viewerA.ref),
+                    viewerB: getSerializableCameraSnapshot(viewerB.ref),
+                },
+            } as SessionUiState,
         }),
         () => {
             const embeddedFiles: Record<string, File | null | undefined> = {};
@@ -1069,14 +1181,49 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
                 );
                 loadedAny = true;
             }
-            // TODO: Restore visibility and representations as needed
+            const uiState = session?.uiState as SessionUiState | undefined;
+            if (uiState?.zoom) {
+                if (Number.isFinite(uiState.zoom.extraRadius)) setZoomExtraRadius(uiState.zoom.extraRadius);
+                if (Number.isFinite(uiState.zoom.minRadius)) setZoomMinRadius(uiState.zoom.minRadius);
+            }
+            if (uiState?.selections?.alignedTo) {
+                if (typeof uiState.selections.alignedTo.subunit === 'string') setSelectedSubunitAlignedTo(uiState.selections.alignedTo.subunit as any);
+                if (typeof uiState.selections.alignedTo.chainId === 'string') setSelectedChainIdAlignedTo(uiState.selections.alignedTo.chainId);
+                if (typeof uiState.selections.alignedTo.residueId === 'string') setSelectedResidueIdAlignedTo(uiState.selections.alignedTo.residueId);
+            }
+            if (uiState?.selections?.aligned) {
+                if (typeof uiState.selections.aligned.subunit === 'string') setSelectedSubunitAligned(uiState.selections.aligned.subunit as any);
+                if (typeof uiState.selections.aligned.chainId === 'string') setSelectedChainIdAligned(uiState.selections.aligned.chainId);
+                if (typeof uiState.selections.aligned.residueId === 'string') setSelectedResidueIdAligned(uiState.selections.aligned.residueId);
+            }
+            if (typeof uiState?.syncEnabled === 'boolean') {
+                setSyncEnabled(uiState.syncEnabled);
+            }
+            if (uiState?.activeViewer === A || uiState?.activeViewer === B) {
+                setActiveViewer(uiState.activeViewer);
+            }
+            if (uiState?.cameraSnapshots) {
+                applySerializableCameraSnapshot(viewerA.ref, uiState.cameraSnapshots.viewerA);
+                applySerializableCameraSnapshot(viewerB.ref, uiState.cameraSnapshots.viewerB);
+            }
+
             if (!loadedAny) {
                 alert('Session loaded, but could not automatically reload datasets. Please reload the required files manually.');
             }
         } catch (e) {
             alert('Error loading session: ' + (e instanceof Error ? e.message : String(e)));
         }
-    }, [loadMoleculeIntoViewers, normalizeSessionRepresentation]);
+    }, [
+        loadMoleculeIntoViewers,
+        normalizeSessionRepresentation,
+        applySerializableCameraSnapshot,
+        setSelectedSubunitAlignedTo,
+        setSelectedSubunitAligned,
+        setSelectedChainIdAlignedTo,
+        setSelectedChainIdAligned,
+        setSelectedResidueIdAlignedTo,
+        setSelectedResidueIdAligned,
+    ]);
 
     // Initialize session load modal with the callback
     const { handleLoadSession, handleLoadAllSession, SessionLoadModal } = useSessionLoadModal(onSessionLoaded);


### PR DESCRIPTION
This release improves session persistence so restored sessions match prior UI/view state more accurately.

Session save/load now preserves Residue Zoom settings (extraRadius, minRadius).
Session save/load now preserves Select states for both columns (Subunit, Chain, Residue).
Session save/load now preserves Select Sync state and active viewer.
Mol* camera snapshots are persisted and restored for both viewers, including orientation and zoom radius.
Integration coverage was expanded for UI state and camera/sync restore paths.
Full test suite passed for this release (197/197).