### PR TITLE
release: v0.8.0 — Family-based chain labelling and species-aware mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v0.8.0] - 2026-06-22
+- Updated chain labels to prefer ribosomal `family` names from `RP_name_table_uniprot.csv` (first column), shown in selectors as `<family> [<label>]` when matched.
+- Added species-aware RP lookup resolution so each dataset uses the correct homolog column (arabidopsis, drosophila, human, yeast) with robust fallback to all-species mapping.
+- Updated chain select option ordering to sort by displayed family label rather than raw chain ID.
+- Added regression tests for species-specific CSV parsing, species inference from mmCIF source metadata, family label resolution, and chain option ordering.
+
 ## [v0.7.4] - 2026-06-22
 - Extended session save/load to persist and restore UI state exactly, including `Residue Zoom` (`extraRadius`, `minRadius`), subunit/chain/residue selections for both columns, sync state, and active viewer.
 - Added camera snapshot persistence for both viewers so orientation and zoom radius are restored on session load.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ribocode1",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ribocode1",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ribocode1",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@
  * @lastModified 2026-06-11
  * @see https://github.com/ribocode-slola/ribocode1
  */
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import { useConfirm } from './hooks/useConfirm';
 import { SelectionProvider } from './context/SelectionContext';
 import { ViewerStateProvider } from './context/ViewerStateContext';
@@ -56,6 +56,8 @@ import type { LoadedMolecule, ViewerKey, MoleculeMode } from './types/ribocode';
 import { A, B } from './constants/ribocode';
 import { makeFogSetters, makeCameraSetters, makeZoomHandler } from './utils/viewerHelpers';
 import { selectedAtomTypes } from './constants/ribocode';
+import { parseRpNameTableBySpecies } from './utils/rpNameTable';
+import rpNameTableCsv from '../data/input/RP_name_table_uniprot.csv?raw';
 
 /**
  * The main App component.
@@ -130,6 +132,10 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
     const [viewerAReady, setViewerAReady] = useState(false);
     const [viewerBReady, setViewerBReady] = useState(false);
     const [syncEnabled, setSyncEnabled] = useState(false);
+    const rpNameLookupBySpecies = useMemo(
+        () => parseRpNameTableBySpecies(rpNameTableCsv),
+        []
+    );
 
     // Use a ref to always have the latest alignmentData from AlignedTo
     const alignmentDataRef = useRef<any>(null);
@@ -725,8 +731,8 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
     );
 
     // Custom hooks for updating chain info and subunit-to-chain mapping for both viewers.
-    useUpdateChainInfo(viewerA.ref, structureRefAAlignedTo, molstarA, setChainInfoAlignedTo, setSubunitToChainIdsAlignedTo, AlignedTo);
-    useUpdateChainInfo(viewerB.ref, structureRefBAligned, molstarB, setChainInfoAligned, setSubunitToChainIdsAligned, Aligned);
+    useUpdateChainInfo(viewerA.ref, structureRefAAlignedTo, molstarA, setChainInfoAlignedTo, setSubunitToChainIdsAlignedTo, AlignedTo, rpNameLookupBySpecies);
+    useUpdateChainInfo(viewerB.ref, structureRefBAligned, molstarB, setChainInfoAligned, setSubunitToChainIdsAligned, Aligned, rpNameLookupBySpecies);
 
     // Generalized effect for residue ID selection and info update.
     useUpdateResidueInfo(viewerA.ref, structureRefAAlignedTo, molstarA, selectedChainIdAlignedTo, setResidueInfoAlignedTo, selectedResidueIdAlignedTo, setSelectedResidueIdAlignedTo, AlignedTo);

--- a/src/components/buttons/select/Chain.test.tsx
+++ b/src/components/buttons/select/Chain.test.tsx
@@ -137,4 +137,24 @@ describe('ChainSelectButton', () => {
         expect(getByText('1')).toBeInTheDocument();
         expect(getByText('2')).toBeInTheDocument();
     });
+
+    it('orders options by label text rather than chain id', () => {
+        const unorderedById = new Map([
+            ['B', 'uL2 [B]'],
+            ['A', 'eS1 [A]'],
+            ['C', 'uS3 [C]']
+        ]);
+        const { getByRole } = render(
+            <ChainSelectButton
+                disabled={false}
+                chainLabels={unorderedById}
+                selectedChainId={''}
+                onSelect={() => {}}
+                id="chain-order-test"
+            />
+        );
+        const select = getByRole('combobox', { name: 'Select Chain' }) as HTMLSelectElement;
+        const optionValues = Array.from(select.options).map(o => o.textContent);
+        expect(optionValues).toEqual(['...', 'eS1 [A]', 'uL2 [B]', 'uS3 [C]']);
+    });
 });

--- a/src/components/buttons/select/Chain.tsx
+++ b/src/components/buttons/select/Chain.tsx
@@ -47,11 +47,11 @@ const ChainSelectButton: React.FC<ChainSelectButtonProps> = ({
 	label,
 	id
 }) => {
-	// Order chainLabels by chainId
-	const orderedEntries = Array.from(chainLabels.entries()).sort(([idA], [idB]) => {
-		if (idA < idB) return -1;
-		if (idA > idB) return 1;
-		return 0;
+	// Order chain labels by display label first (e.g. family name), then chainId.
+	const orderedEntries = Array.from(chainLabels.entries()).sort(([idA, labelA], [idB, labelB]) => {
+		const byLabel = labelA.localeCompare(labelB, undefined, { numeric: true, sensitivity: 'base' });
+		if (byLabel !== 0) return byLabel;
+		return idA.localeCompare(idB, undefined, { numeric: true, sensitivity: 'base' });
 	});
 	return (
 		<label>

--- a/src/hooks/useUpdateChainInfo.ts
+++ b/src/hooks/useUpdateChainInfo.ts
@@ -10,6 +10,7 @@
  */
 import { useEffect } from 'react';
 import { getChainInfo } from '../utils/chain';
+import { RpNameLookupBySpecies } from '../utils/rpNameTable';
 
 /**
  * Custom hook to update chain info and subunit-to-chain mapping for a Mol* structure.
@@ -30,7 +31,7 @@ export function useUpdateChainInfo(
   setChainInfo: React.Dispatch<React.SetStateAction<{ chainLabels: Map<string, string> }>>,
   setSubunitToChainIds: React.Dispatch<React.SetStateAction<Map<string, Set<string>>>>,
   label?: string,
-  rpNameLookup?: Map<string, string>
+  rpNameLookup?: Map<string, string> | RpNameLookupBySpecies
 ) {
   useEffect(() => {
     if (!pluginRef.current || !structureRef) return;

--- a/src/types/assets.d.ts
+++ b/src/types/assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.csv?raw' {
+  const content: string;
+  export default content;
+}

--- a/src/utils/chain.test.ts
+++ b/src/utils/chain.test.ts
@@ -10,6 +10,7 @@
  */
 import { vi } from 'vitest';
 import { getChainInfo } from './chain';
+import { RpNameLookupBySpecies } from './rpNameTable';
 
 describe('getChainInfo', () => {
     let originalWarn: any;
@@ -175,5 +176,95 @@ describe('getChainInfo with rpNameLookup enrichment', () => {
         });
         const result = getChainInfo(structure, rpNameLookup);
         expect(result.chainLabels.get('A')).toBe('eS1 [A]');
+    });
+
+    it('uses species-specific lookup when available', () => {
+        const rpNameLookupBySpecies: RpNameLookupBySpecies = {
+            all: new Map([['P61247', 'ALL_FAMILY']]),
+            arabidopsis: new Map(),
+            drosophila: new Map(),
+            human: new Map([['P61247', 'HUMAN_FAMILY']]),
+            yeast: new Map([['P61247', 'YEAST_FAMILY']]),
+        };
+
+        const structure = {
+            units: [
+                {
+                    model: {
+                        atomicHierarchy: {
+                            chains: {
+                                _rowCount: 1,
+                                auth_asym_id: { value: () => 'A' },
+                                label_asym_id: { value: () => 'AA' },
+                                label_entity_id: { value: () => '1' },
+                            }
+                        },
+                        sourceData: {
+                            data: {
+                                db: {
+                                    struct_ref: {
+                                        _rowCount: 1,
+                                        entity_id: { value: () => '1' },
+                                        pdbx_db_accession: { value: () => 'P61247' }
+                                    },
+                                    entity_src_nat: {
+                                        _rowCount: 1,
+                                        pdbx_organism_scientific: { value: () => 'Homo sapiens' }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        } as any;
+
+        const result = getChainInfo(structure, rpNameLookupBySpecies);
+        expect(result.chainLabels.get('A')).toBe('HUMAN_FAMILY [AA]');
+    });
+
+    it('falls back to all-species lookup when species is unknown', () => {
+        const rpNameLookupBySpecies: RpNameLookupBySpecies = {
+            all: new Map([['P61247', 'ALL_FAMILY']]),
+            arabidopsis: new Map(),
+            drosophila: new Map(),
+            human: new Map(),
+            yeast: new Map(),
+        };
+
+        const structure = {
+            units: [
+                {
+                    model: {
+                        atomicHierarchy: {
+                            chains: {
+                                _rowCount: 1,
+                                auth_asym_id: { value: () => 'A' },
+                                label_asym_id: { value: () => 'AA' },
+                                label_entity_id: { value: () => '1' },
+                            }
+                        },
+                        sourceData: {
+                            data: {
+                                db: {
+                                    struct_ref: {
+                                        _rowCount: 1,
+                                        entity_id: { value: () => '1' },
+                                        pdbx_db_accession: { value: () => 'P61247' }
+                                    },
+                                    entity_src_nat: {
+                                        _rowCount: 1,
+                                        pdbx_organism_scientific: { value: () => 'Unknown organism' }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        } as any;
+
+        const result = getChainInfo(structure, rpNameLookupBySpecies);
+        expect(result.chainLabels.get('A')).toBe('ALL_FAMILY [AA]');
     });
 });

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -9,7 +9,13 @@
  * @see https://github.com/ribocode-slola/ribocode1
  */
 import { Structure } from 'molstar/lib/mol-model/structure';
-import { buildEntityToUniprotMap } from './rpNameTable';
+import { buildEntityToUniprotMap, inferSpeciesKeyFromModel, RpNameLookupBySpecies } from './rpNameTable';
+
+function isLookupBySpecies(
+    lookup?: Map<string, string> | RpNameLookupBySpecies
+): lookup is RpNameLookupBySpecies {
+    return !!lookup && typeof lookup === 'object' && 'all' in lookup;
+}
 
 /**
  * Extracts chain IDs and labels from a Mol* Structure object.
@@ -28,7 +34,7 @@ import { buildEntityToUniprotMap } from './rpNameTable';
  */
 export function getChainInfo(
     structure: Structure,
-    rpNameLookup?: Map<string, string>
+    rpNameLookup?: Map<string, string> | RpNameLookupBySpecies
 ): { chainLabels: Map<string, string> } {
     const chainLabels: Map<string, string> = new Map();
     const units = structure.units;
@@ -51,6 +57,13 @@ export function getChainInfo(
             entityToUniprot = buildEntityToUniprotMap(model);
         }
 
+        const speciesKey = isLookupBySpecies(rpNameLookup)
+            ? inferSpeciesKeyFromModel(model)
+            : undefined;
+        const activeLookup = isLookupBySpecies(rpNameLookup)
+            ? (speciesKey ? rpNameLookup[speciesKey] : rpNameLookup.all)
+            : rpNameLookup;
+
         for (let i = 0; i < chains._rowCount; i++) {
             const authId: string = auth_asym_id.value(i);
             if (chainLabels.has(authId)) continue; // deduplicate across units
@@ -65,7 +78,10 @@ export function getChainInfo(
                     : undefined;
                 const uniprot = entityId ? entityToUniprot.get(entityId) : undefined;
                 if (uniprot) {
-                    familyName = rpNameLookup.get(uniprot);
+                    familyName = activeLookup?.get(uniprot);
+                    if (!familyName && isLookupBySpecies(rpNameLookup)) {
+                        familyName = rpNameLookup.all.get(uniprot);
+                    }
                 }
             }
 

--- a/src/utils/rpNameTable.test.ts
+++ b/src/utils/rpNameTable.test.ts
@@ -8,7 +8,7 @@
  * @lastModified 2026-06-22
  * @see https://github.com/ribocode-slola/ribocode1
  */
-import { parseRpNameTable, buildEntityToUniprotMap } from './rpNameTable';
+import { parseRpNameTable, parseRpNameTableBySpecies, buildEntityToUniprotMap, inferSpeciesKeyFromModel } from './rpNameTable';
 
 describe('parseRpNameTable', () => {
     const HEADER = 'family,human_old_name,yeast_old_name,arabdidopsis_homologs,drosophila_homologs,human_homologs,yeast_homologs';
@@ -49,6 +49,21 @@ describe('parseRpNameTable', () => {
         expect(lookup.get('P23396')).toBe('uS3');
         // yeast (col 6)
         expect(lookup.get('A0A6A5Q3Q1')).toBe('uS3');
+    });
+
+    it('can parse only the selected species column', () => {
+        const csv = [
+            HEADER,
+            'uS2,S0,SA,ARA_ONLY,DRO_ONLY,HUMAN_ONLY,YEAST_ONLY'
+        ].join('\n');
+
+        const humanLookup = parseRpNameTable(csv, 'human');
+        const yeastLookup = parseRpNameTable(csv, 'yeast');
+
+        expect(humanLookup.get('HUMAN_ONLY')).toBe('uS2');
+        expect(humanLookup.has('YEAST_ONLY')).toBe(false);
+        expect(yeastLookup.get('YEAST_ONLY')).toBe('uS2');
+        expect(yeastLookup.has('HUMAN_ONLY')).toBe(false);
     });
 
     it('ignores blank lines in the CSV', () => {
@@ -98,6 +113,76 @@ describe('parseRpNameTable', () => {
         expect(lookup.get('B9DG17')).toBe('uS2');
         expect(lookup.get('P38979')).toBe('uS2');
         expect(lookup.get('P46654')).toBe('uS2');
+    });
+});
+
+describe('parseRpNameTableBySpecies', () => {
+    const HEADER = 'family,human_old_name,yeast_old_name,arabdidopsis_homologs,drosophila_homologs,human_homologs,yeast_homologs';
+
+    it('returns distinct lookups for each species and all columns', () => {
+        const csv = [
+            HEADER,
+            'eS1,S1,S3A,ARA1,DRO1,HUM1,YEA1'
+        ].join('\n');
+
+        const lookups = parseRpNameTableBySpecies(csv);
+
+        expect(lookups.arabidopsis.get('ARA1')).toBe('eS1');
+        expect(lookups.drosophila.get('DRO1')).toBe('eS1');
+        expect(lookups.human.get('HUM1')).toBe('eS1');
+        expect(lookups.yeast.get('YEA1')).toBe('eS1');
+        expect(lookups.all.get('ARA1')).toBe('eS1');
+        expect(lookups.all.get('YEA1')).toBe('eS1');
+    });
+});
+
+describe('inferSpeciesKeyFromModel', () => {
+    it('detects human from entity_src_nat scientific name', () => {
+        const model = {
+            sourceData: {
+                data: {
+                    db: {
+                        entity_src_nat: {
+                            _rowCount: 1,
+                            pdbx_organism_scientific: { value: () => 'Homo sapiens' }
+                        }
+                    }
+                }
+            }
+        };
+        expect(inferSpeciesKeyFromModel(model)).toBe('human');
+    });
+
+    it('detects yeast from pdbx_entity_src_syn scientific name', () => {
+        const model = {
+            sourceData: {
+                data: {
+                    db: {
+                        pdbx_entity_src_syn: {
+                            _rowCount: 1,
+                            organism_scientific: { value: () => 'Saccharomyces cerevisiae' }
+                        }
+                    }
+                }
+            }
+        };
+        expect(inferSpeciesKeyFromModel(model)).toBe('yeast');
+    });
+
+    it('returns undefined when no known species is found', () => {
+        const model = {
+            sourceData: {
+                data: {
+                    db: {
+                        entity_src_nat: {
+                            _rowCount: 1,
+                            pdbx_organism_scientific: { value: () => 'Unknown organism' }
+                        }
+                    }
+                }
+            }
+        };
+        expect(inferSpeciesKeyFromModel(model)).toBeUndefined();
     });
 });
 

--- a/src/utils/rpNameTable.ts
+++ b/src/utils/rpNameTable.ts
@@ -18,11 +18,33 @@
  * @see https://github.com/ribocode-slola/ribocode1
  */
 
+export type RpSpeciesKey = 'arabidopsis' | 'drosophila' | 'human' | 'yeast';
+
 /**
  * Column indices in the CSV that hold semicolon-separated UniProt accession codes.
  * 0=family, 1=human_old_name, 2=yeast_old_name, 3=arabidopsis, 4=drosophila, 5=human, 6=yeast
  */
-const UNIPROT_COL_INDICES = [3, 4, 5, 6];
+const UNIPROT_COL_INDEX_BY_SPECIES: Record<RpSpeciesKey, number> = {
+    arabidopsis: 3,
+    drosophila: 4,
+    human: 5,
+    yeast: 6,
+};
+
+const ALL_SPECIES: RpSpeciesKey[] = ['arabidopsis', 'drosophila', 'human', 'yeast'];
+
+export interface RpNameLookupBySpecies {
+    all: Map<string, string>;
+    arabidopsis: Map<string, string>;
+    drosophila: Map<string, string>;
+    human: Map<string, string>;
+    yeast: Map<string, string>;
+}
+
+function normalizeSpeciesSelection(species?: RpSpeciesKey | RpSpeciesKey[]): RpSpeciesKey[] {
+    if (!species) return ALL_SPECIES;
+    return Array.isArray(species) ? species : [species];
+}
 
 /**
  * Parses the RP_name_table_uniprot.csv content into a lookup map.
@@ -33,9 +55,14 @@ const UNIPROT_COL_INDICES = [3, 4, 5, 6];
  * @param csvText - Raw text content of RP_name_table_uniprot.csv.
  * @returns Map from UniProt accession code → gene family name.
  */
-export function parseRpNameTable(csvText: string): Map<string, string> {
+export function parseRpNameTable(
+    csvText: string,
+    species?: RpSpeciesKey | RpSpeciesKey[]
+): Map<string, string> {
     const lookup = new Map<string, string>();
     const lines = csvText.split('\n');
+    const selectedSpecies = normalizeSpeciesSelection(species);
+    const selectedColumns = selectedSpecies.map(s => UNIPROT_COL_INDEX_BY_SPECIES[s]);
     // Skip header row (line 0)
     for (let i = 1; i < lines.length; i++) {
         const line = lines[i].trim();
@@ -43,7 +70,7 @@ export function parseRpNameTable(csvText: string): Map<string, string> {
         const cols = line.split(',');
         const family = cols[0]?.trim();
         if (!family) continue;
-        for (const ci of UNIPROT_COL_INDICES) {
+        for (const ci of selectedColumns) {
             const cellValue = cols[ci] || '';
             const codes = cellValue.split(';');
             for (const code of codes) {
@@ -55,6 +82,49 @@ export function parseRpNameTable(csvText: string): Map<string, string> {
         }
     }
     return lookup;
+}
+
+/**
+ * Builds lookups for all species columns and each individual species column.
+ */
+export function parseRpNameTableBySpecies(csvText: string): RpNameLookupBySpecies {
+    return {
+        all: parseRpNameTable(csvText),
+        arabidopsis: parseRpNameTable(csvText, 'arabidopsis'),
+        drosophila: parseRpNameTable(csvText, 'drosophila'),
+        human: parseRpNameTable(csvText, 'human'),
+        yeast: parseRpNameTable(csvText, 'yeast'),
+    };
+}
+
+/**
+ * Best-effort detection of source species for a model from mmCIF entity source categories.
+ */
+export function inferSpeciesKeyFromModel(model: any): RpSpeciesKey | undefined {
+    const db = model?.sourceData?.data?.db;
+    if (!db) return undefined;
+
+    const names: string[] = [];
+    const pushValues = (category: any, fieldName: string) => {
+        if (!category || !category[fieldName]?.value) return;
+        const rowCount = category._rowCount ?? 0;
+        for (let i = 0; i < rowCount; i++) {
+            const value = category[fieldName].value(i);
+            if (value) names.push(String(value).toLowerCase());
+        }
+    };
+
+    pushValues(db.entity_src_nat, 'pdbx_organism_scientific');
+    pushValues(db.pdbx_entity_src_syn, 'organism_scientific');
+    pushValues(db.entity_src_gen, 'pdbx_gene_src_scientific_name');
+
+    const text = names.join(' | ');
+    if (!text) return undefined;
+    if (/arabidopsis/.test(text)) return 'arabidopsis';
+    if (/drosophila/.test(text)) return 'drosophila';
+    if (/homo\s+sapiens|human/.test(text)) return 'human';
+    if (/saccharomyces|yeast/.test(text)) return 'yeast';
+    return undefined;
 }
 
 /**


### PR DESCRIPTION
This release improves chain naming clarity and ordering in selection controls.

Chain labels now prefer ribosomal family names from the [family](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) column of [RP_name_table_uniprot.csv](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html), displayed as [family [label]](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html) when matched.
Mapping is now species-aware: the correct homolog column is selected per dataset (arabidopsis, drosophila, human, yeast), with safe fallback to all-species lookup when species cannot be inferred.
Chain options in selectors are now sorted by displayed label (family-first) instead of raw chain ID.
Added tests for species-specific CSV parsing, species inference from mmCIF source metadata, family label resolution, and label-based chain ordering.
Added raw CSV import typing support for TypeScript.
Quality checks:

Full test suite passed: 205/205.
Release tag: v0.8.0.
Deployment: published via gh-pages.