### PR TITLE
v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [v0.8.1] - 2026-06-22
 - Fixed session restore representation matching so saved color themes are preserved; type-only matches with different themes are now replaced with the saved representation.
+- Added UniProt gene-name enrichment for chain labels with background, rate-limited lookup and session-cached results.
+- Added a `Show UniProt accession in chain labels` toggle in `General Controls`, persisted in session `uiState` and restored on load.
 
 ## [v0.8.0] - 2026-06-22
 - Updated chain labels to prefer ribosomal `family` names from `RP_name_table_uniprot.csv` (first column), shown in selectors as `<family> [<label>]` when matched.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## [v0.8.1] - 2026-06-22
-- Fixed session restore representation matching so saved color themes are preserved; type-only matches with different themes are now replaced with the saved representation.
+## [v0.8.2] - 2026-06-22
 - Added UniProt gene-name enrichment for chain labels with background, rate-limited lookup and session-cached results.
 - Added a `Show UniProt accession in chain labels` toggle in `General Controls`, persisted in session `uiState` and restored on load.
+
+## [v0.8.1] - 2026-06-22
+- Fixed session restore representation matching so saved color themes are preserved; type-only matches with different themes are now replaced with the saved representation.
 
 ## [v0.8.0] - 2026-06-22
 - Updated chain labels to prefer ribosomal `family` names from `RP_name_table_uniprot.csv` (first column), shown in selectors as `<family> [<label>]` when matched.

--- a/UserGuide.md
+++ b/UserGuide.md
@@ -24,6 +24,7 @@ The UI layout is as follows:
  - `General Controls`
    - `Resdue Zoom` controls
    - `Select Sync` control for synchronization
+   - `Show UniProt accession in chain labels` toggle for chain selector labels
    - `Re-align to Chains` control
  - Column `A`
    - `Load Molecule`
@@ -136,5 +137,7 @@ Sychronization is `Off` by default. If selected to be `On`, rotation/zoom in one
 Please refer to the [Mol* viewer Documentation](https://molstar.org/viewer-docs/) for details of the Mol* UI. In each Ribocode `Molstar Container`, the `Mol* 3D Canvas` is always visible and the additional Mol* panels (`Sequence Panel`, `Main Menu`, `Control Panel`, `Log Panel`) are hidden by default for a cleaner workflow. Use the `Show Advanced Mol* Controls` button in a column to reveal these panels for advanced usage, and `Hide Advanced Mol* Controls` to collapse them again. The Mol* viewer style is adapted so that the UI fits in a column of 600 pixels in width.
 
 For convenience, users can save and load a session via the Session Menu. Loading a session does not load the data. For security reasons data loading is a manual process, but once the `AlignedTo` and `Aligned` data are selected, the representations are recreated and the loaded session should be in the state it was when the session was saved.
+
+Session `uiState` also persists the `Show UniProt accession in chain labels` setting, so chain label formatting is restored consistently when a session is loaded.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ribocode1",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ribocode1",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ribocode1",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/App.integration.test.tsx
+++ b/src/App.integration.test.tsx
@@ -440,6 +440,7 @@ describe('App integration: AlignedTo and Aligned loading', () => {
     fireEvent.change(document.getElementById('generalcontrols-zoom-extra-radius') as HTMLInputElement, { target: { value: '24' } });
     fireEvent.change(document.getElementById('generalcontrols-zoom-min-radius') as HTMLInputElement, { target: { value: '12' } });
     fireEvent.change(document.getElementById('generalcontrols-sync-select') as HTMLSelectElement, { target: { value: 'On' } });
+    fireEvent.click(document.getElementById('generalcontrols-show-uniprot-accession') as HTMLInputElement);
     fireEvent.change(document.getElementById('viewer-column-A-alignedto-subunit-select') as HTMLSelectElement, { target: { value: 'Large' } });
     fireEvent.change(document.getElementById('viewer-column-B-aligned-subunit-select') as HTMLSelectElement, { target: { value: 'Small' } });
 
@@ -449,6 +450,7 @@ describe('App integration: AlignedTo and Aligned loading', () => {
 
     expect(session.uiState.zoom).toEqual({ extraRadius: 24, minRadius: 12 });
     expect(session.uiState.syncEnabled).toBe(true);
+    expect(session.uiState.showUniprotAccessionInChainLabels).toBe(false);
     expect(session.uiState.selections.alignedTo).toEqual(expect.objectContaining({
       subunit: 'Large',
     }));
@@ -472,6 +474,7 @@ describe('App integration: AlignedTo and Aligned loading', () => {
       uiState: {
         zoom: { extraRadius: 31, minRadius: 14 },
         syncEnabled: true,
+        showUniprotAccessionInChainLabels: false,
         selections: {
           alignedTo: { subunit: 'Large', chainId: 'A', residueId: '10' },
           aligned: { subunit: 'Small', chainId: 'B', residueId: '20' },
@@ -498,6 +501,7 @@ describe('App integration: AlignedTo and Aligned loading', () => {
       expect((document.getElementById('generalcontrols-zoom-extra-radius') as HTMLInputElement).value).toBe('31');
       expect((document.getElementById('generalcontrols-zoom-min-radius') as HTMLInputElement).value).toBe('14');
       expect((document.getElementById('generalcontrols-sync-select') as HTMLSelectElement).value).toBe('On');
+      expect((document.getElementById('generalcontrols-show-uniprot-accession') as HTMLInputElement).checked).toBe(false);
     }, { timeout: 5000 });
 
     expect(pluginA.canvas3d.camera.setState).toHaveBeenCalledWith(expect.objectContaining({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,6 +57,7 @@ import { A, B } from './constants/ribocode';
 import { makeFogSetters, makeCameraSetters, makeZoomHandler } from './utils/viewerHelpers';
 import { selectedAtomTypes } from './constants/ribocode';
 import { parseRpNameTableBySpecies } from './utils/rpNameTable';
+import { fetchUniProtGeneNamesBatched, UniProtGeneNameCache } from './utils/uniprot';
 import rpNameTableCsv from '../data/input/RP_name_table_uniprot.csv?raw';
 
 /**
@@ -103,6 +104,8 @@ interface SessionUiState {
         viewerA?: SerializableCameraSnapshot;
         viewerB?: SerializableCameraSnapshot;
     };
+    uniprotGeneNames?: UniProtGeneNameCache;
+    showUniprotAccessionInChainLabels?: boolean;
 }
 
 const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
@@ -132,10 +135,71 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
     const [viewerAReady, setViewerAReady] = useState(false);
     const [viewerBReady, setViewerBReady] = useState(false);
     const [syncEnabled, setSyncEnabled] = useState(false);
+    const [showUniprotAccessionInChainLabels, setShowUniprotAccessionInChainLabels] = useState(true);
     const rpNameLookupBySpecies = useMemo(
         () => parseRpNameTableBySpecies(rpNameTableCsv),
         []
     );
+    const [uniprotGeneNames, setUniprotGeneNames] = useState<UniProtGeneNameCache>({});
+    const uniprotGeneNamesRef = useRef<UniProtGeneNameCache>({});
+    const pendingUniProtAccessionsRef = useRef<Set<string>>(new Set());
+    const inFlightUniProtAccessionsRef = useRef<Set<string>>(new Set());
+    const isProcessingUniProtQueueRef = useRef(false);
+
+    useEffect(() => {
+        uniprotGeneNamesRef.current = uniprotGeneNames;
+    }, [uniprotGeneNames]);
+
+    const processUniProtQueue = useCallback(async () => {
+        if (isProcessingUniProtQueueRef.current) return;
+        if (typeof fetch !== 'function' || process.env.NODE_ENV === 'test') return;
+
+        isProcessingUniProtQueueRef.current = true;
+        try {
+            while (pendingUniProtAccessionsRef.current.size > 0) {
+                const pending = Array.from(pendingUniProtAccessionsRef.current);
+                pendingUniProtAccessionsRef.current.clear();
+
+                const unresolved = pending.filter(accession => {
+                    if (accession in uniprotGeneNamesRef.current) return false;
+                    if (inFlightUniProtAccessionsRef.current.has(accession)) return false;
+                    return true;
+                });
+
+                if (!unresolved.length) continue;
+
+                unresolved.forEach(accession => inFlightUniProtAccessionsRef.current.add(accession));
+                const resolved = await fetchUniProtGeneNamesBatched(unresolved, {
+                    batchSize: 20,
+                    delayMs: 1200,
+                });
+                setUniprotGeneNames(prev => ({ ...prev, ...resolved }));
+                unresolved.forEach(accession => inFlightUniProtAccessionsRef.current.delete(accession));
+            }
+        } finally {
+            isProcessingUniProtQueueRef.current = false;
+            if (pendingUniProtAccessionsRef.current.size > 0) {
+                void processUniProtQueue();
+            }
+        }
+    }, []);
+
+    const onUniprotAccessionsDiscovered = useCallback((accessions: Iterable<string>) => {
+        let hasQueuedAny = false;
+        for (const raw of accessions) {
+            const accession = raw.trim();
+            if (!accession) continue;
+            if (accession in uniprotGeneNamesRef.current) continue;
+            if (inFlightUniProtAccessionsRef.current.has(accession)) continue;
+            if (pendingUniProtAccessionsRef.current.has(accession)) continue;
+            pendingUniProtAccessionsRef.current.add(accession);
+            hasQueuedAny = true;
+        }
+
+        if (hasQueuedAny) {
+            void processUniProtQueue();
+        }
+    }, [processUniProtQueue]);
 
     // Use a ref to always have the latest alignmentData from AlignedTo
     const alignmentDataRef = useRef<any>(null);
@@ -748,8 +812,30 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
     );
 
     // Custom hooks for updating chain info and subunit-to-chain mapping for both viewers.
-    useUpdateChainInfo(viewerA.ref, structureRefAAlignedTo, molstarA, setChainInfoAlignedTo, setSubunitToChainIdsAlignedTo, AlignedTo, rpNameLookupBySpecies);
-    useUpdateChainInfo(viewerB.ref, structureRefBAligned, molstarB, setChainInfoAligned, setSubunitToChainIdsAligned, Aligned, rpNameLookupBySpecies);
+    useUpdateChainInfo(
+        viewerA.ref,
+        structureRefAAlignedTo,
+        molstarA,
+        setChainInfoAlignedTo,
+        setSubunitToChainIdsAlignedTo,
+        AlignedTo,
+        rpNameLookupBySpecies,
+        uniprotGeneNames,
+        onUniprotAccessionsDiscovered,
+        showUniprotAccessionInChainLabels
+    );
+    useUpdateChainInfo(
+        viewerB.ref,
+        structureRefBAligned,
+        molstarB,
+        setChainInfoAligned,
+        setSubunitToChainIdsAligned,
+        Aligned,
+        rpNameLookupBySpecies,
+        uniprotGeneNames,
+        onUniprotAccessionsDiscovered,
+        showUniprotAccessionInChainLabels
+    );
 
     // Generalized effect for residue ID selection and info update.
     useUpdateResidueInfo(viewerA.ref, structureRefAAlignedTo, molstarA, selectedChainIdAlignedTo, setResidueInfoAlignedTo, selectedResidueIdAlignedTo, setSelectedResidueIdAlignedTo, AlignedTo);
@@ -1047,6 +1133,8 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
                 viewerA: getSerializableCameraSnapshot(viewerA.ref),
                 viewerB: getSerializableCameraSnapshot(viewerB.ref),
             },
+            uniprotGeneNames,
+            showUniprotAccessionInChainLabels,
         } as SessionUiState,
     }));
 
@@ -1107,6 +1195,8 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
                     viewerA: getSerializableCameraSnapshot(viewerA.ref),
                     viewerB: getSerializableCameraSnapshot(viewerB.ref),
                 },
+                uniprotGeneNames,
+                showUniprotAccessionInChainLabels,
             } as SessionUiState,
         }),
         () => {
@@ -1229,6 +1319,12 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
                 applySerializableCameraSnapshot(viewerA.ref, uiState.cameraSnapshots.viewerA);
                 applySerializableCameraSnapshot(viewerB.ref, uiState.cameraSnapshots.viewerB);
             }
+            if (uiState?.uniprotGeneNames && typeof uiState.uniprotGeneNames === 'object') {
+                setUniprotGeneNames(prev => ({ ...prev, ...uiState.uniprotGeneNames }));
+            }
+            if (typeof uiState?.showUniprotAccessionInChainLabels === 'boolean') {
+                setShowUniprotAccessionInChainLabels(uiState.showUniprotAccessionInChainLabels);
+            }
 
             if (!loadedAny) {
                 alert('Session loaded, but could not automatically reload datasets. Please reload the required files manually.');
@@ -1246,6 +1342,8 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
         setSelectedChainIdAligned,
         setSelectedResidueIdAlignedTo,
         setSelectedResidueIdAligned,
+        setUniprotGeneNames,
+        setShowUniprotAccessionInChainLabels,
     ]);
 
     // Initialize session load modal with the callback
@@ -1430,6 +1528,8 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
                         setZoomExtraRadius={setZoomExtraRadius}
                         zoomMinRadius={zoomMinRadius}
                         setZoomMinRadius={setZoomMinRadius}
+                        showUniprotAccessionInChainLabels={showUniprotAccessionInChainLabels}
+                        setShowUniprotAccessionInChainLabels={setShowUniprotAccessionInChainLabels}
                         viewerA={viewerA.ref.current}
                         viewerB={viewerB.ref.current}
                         activeViewer={activeViewer}

--- a/src/components/GeneralControls.test.tsx
+++ b/src/components/GeneralControls.test.tsx
@@ -18,6 +18,7 @@ describe('GeneralControls', () => {
   it('renders and responds to user input', () => {
     const setZoomExtraRadius = vi.fn();
     const setZoomMinRadius = vi.fn();
+    const setShowUniprotAccessionInChainLabels = vi.fn();
     const setSyncEnabled = vi.fn();
     const handleRealignToChains = vi.fn();
     const props = {
@@ -25,6 +26,8 @@ describe('GeneralControls', () => {
       setZoomExtraRadius,
       zoomMinRadius: 16,
       setZoomMinRadius,
+      showUniprotAccessionInChainLabels: true,
+      setShowUniprotAccessionInChainLabels,
       viewerA: {},
       viewerB: {},
       activeViewer: 'A' as ViewerKey,
@@ -50,6 +53,10 @@ describe('GeneralControls', () => {
     const minRadiusInput = getByLabelText(/minRadius/i);
     fireEvent.change(minRadiusInput, { target: { value: '18' } });
     expect(setZoomMinRadius).toHaveBeenCalledWith(18);
+
+    const showUniProtToggle = getByLabelText(/Show UniProt accession in chain labels/i);
+    fireEvent.click(showUniProtToggle);
+    expect(setShowUniprotAccessionInChainLabels).toHaveBeenCalledWith(false);
 
     // Test SyncButton (actually a select) is rendered and works
     const syncSelect = getByLabelText(/Select Sync/i);
@@ -78,6 +85,8 @@ describe('GeneralControls', () => {
       setZoomExtraRadius: vi.fn(),
       zoomMinRadius: 16,
       setZoomMinRadius: vi.fn(),
+      showUniprotAccessionInChainLabels: true,
+      setShowUniprotAccessionInChainLabels: vi.fn(),
       viewerA: {},
       viewerB: {},
       activeViewer: 'A' as ViewerKey,

--- a/src/components/GeneralControls.tsx
+++ b/src/components/GeneralControls.tsx
@@ -40,6 +40,8 @@ interface GeneralControlsProps {
   setZoomExtraRadius: (v: number) => void;
   zoomMinRadius: number;
   setZoomMinRadius: (v: number) => void;
+  showUniprotAccessionInChainLabels: boolean;
+  setShowUniprotAccessionInChainLabels: (v: boolean) => void;
   viewerA: any;
   viewerB: any;
   activeViewer: ViewerKey;
@@ -63,6 +65,8 @@ const GeneralControls: React.FC<GeneralControlsProps> = ({
   setZoomExtraRadius,
   zoomMinRadius,
   setZoomMinRadius,
+  showUniprotAccessionInChainLabels,
+  setShowUniprotAccessionInChainLabels,
   viewerA,
   viewerB,
   activeViewer,
@@ -102,6 +106,16 @@ const GeneralControls: React.FC<GeneralControlsProps> = ({
           onChange={e => setZoomMinRadius(Number(e.target.value))}
           id={`${idPrefix}-zoom-min-radius`}
         />
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={showUniprotAccessionInChainLabels}
+          onChange={e => setShowUniprotAccessionInChainLabels(e.target.checked)}
+          id={`${idPrefix}-show-uniprot-accession`}
+          style={{ marginRight: 4 }}
+        />
+        Show UniProt accession in chain labels
       </label>
     </div>
     <SyncButton

--- a/src/hooks/useUpdateChainInfo.test.tsx
+++ b/src/hooks/useUpdateChainInfo.test.tsx
@@ -130,7 +130,7 @@ describe('useUpdateChainInfo', () => {
     expect(setChainInfo).toHaveBeenCalled();
     const updater = setChainInfo.mock.calls[0][0];
     const result = updater({ chainLabels: new Map() });
-    expect(result.chainLabels.get('A')).toBe('eS1 [AA]');
+    expect(result.chainLabels.get('A')).toBe('eS1 | P61247 [AA]');
   });
 
   it('does nothing if pluginRef.current is null', () => {

--- a/src/hooks/useUpdateChainInfo.ts
+++ b/src/hooks/useUpdateChainInfo.ts
@@ -31,7 +31,10 @@ export function useUpdateChainInfo(
   setChainInfo: React.Dispatch<React.SetStateAction<{ chainLabels: Map<string, string> }>>,
   setSubunitToChainIds: React.Dispatch<React.SetStateAction<Map<string, Set<string>>>>,
   label?: string,
-  rpNameLookup?: Map<string, string> | RpNameLookupBySpecies
+  rpNameLookup?: Map<string, string> | RpNameLookupBySpecies,
+  geneNameLookup?: Record<string, string | null>,
+  onUniprotAccessionsDiscovered?: (accessions: Iterable<string>) => void,
+  showUniprotAccessionInChainLabels = true
 ) {
   useEffect(() => {
     if (!pluginRef.current || !structureRef) return;
@@ -45,7 +48,16 @@ export function useUpdateChainInfo(
       if (!structureObj) return;
 
       // Use getChainInfo to extract auth-based chain labels (with optional family name enrichment)
-      const { chainLabels } = getChainInfo(structureObj, rpNameLookup);
+      const { chainLabels, uniprotAccessions } = getChainInfo(
+        structureObj,
+        rpNameLookup,
+        geneNameLookup,
+        showUniprotAccessionInChainLabels
+      );
+
+      if (onUniprotAccessionsDiscovered && uniprotAccessions.size > 0) {
+        onUniprotAccessionsDiscovered(uniprotAccessions);
+      }
 
       // Build subunit-to-chain mapping (subunit defaults to 'default' for all chains)
       const subunitToChainIds = new Map<string, Set<string>>();
@@ -103,5 +115,5 @@ export function useUpdateChainInfo(
       console.warn(`[useUpdateChainInfo][${label}] failed:`, err);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pluginRef, structureRef, molstar, setChainInfo, setSubunitToChainIds, label, rpNameLookup]);
+  }, [pluginRef, structureRef, molstar, setChainInfo, setSubunitToChainIds, label, rpNameLookup, geneNameLookup, onUniprotAccessionsDiscovered, showUniprotAccessionInChainLabels]);
 }

--- a/src/utils/chain.test.ts
+++ b/src/utils/chain.test.ts
@@ -137,10 +137,34 @@ describe('getChainInfo with rpNameLookup enrichment', () => {
             structRef: [{ entityId: '1', accession: 'P61247' }]
         });
         const result = getChainInfo(structure, rpNameLookup);
-        expect(result.chainLabels.get('A')).toBe('eS1 [AA]');
+        expect(result.chainLabels.get('A')).toBe('eS1 | P61247 [AA]');
     });
 
-    it('falls back to default label when UniProt is not in rpNameLookup', () => {
+    it('uses gene name when available for UniProt accession', () => {
+        const rpNameLookup = new Map([['P61247', 'eS1']]);
+        const structure = makeStructure({
+            authId: 'A',
+            labelId: 'AA',
+            entityId: '1',
+            structRef: [{ entityId: '1', accession: 'P61247' }]
+        });
+        const result = getChainInfo(structure, rpNameLookup, { P61247: 'RPS3A' });
+        expect(result.chainLabels.get('A')).toBe('eS1 | RPS3A (P61247) [AA]');
+    });
+
+    it('hides UniProt accession from label when configured', () => {
+        const rpNameLookup = new Map([['P61247', 'eS1']]);
+        const structure = makeStructure({
+            authId: 'A',
+            labelId: 'AA',
+            entityId: '1',
+            structRef: [{ entityId: '1', accession: 'P61247' }]
+        });
+        const result = getChainInfo(structure, rpNameLookup, { P61247: 'RPS3A' }, false);
+        expect(result.chainLabels.get('A')).toBe('eS1 | RPS3A [AA]');
+    });
+
+    it('falls back to UniProt accession label when family mapping is unavailable', () => {
         const rpNameLookup = new Map([['P99999', 'someFamily']]); // P61247 not present
         const structure = makeStructure({
             authId: 'A',
@@ -149,7 +173,7 @@ describe('getChainInfo with rpNameLookup enrichment', () => {
             structRef: [{ entityId: '1', accession: 'P61247' }]
         });
         const result = getChainInfo(structure, rpNameLookup);
-        expect(result.chainLabels.get('A')).toBe('AA [auth A]');
+        expect(result.chainLabels.get('A')).toBe('P61247 [AA]');
     });
 
     it('falls back to default label when struct_ref is absent', () => {
@@ -175,7 +199,7 @@ describe('getChainInfo with rpNameLookup enrichment', () => {
             structRef: [{ entityId: '1', accession: 'P61247' }]
         });
         const result = getChainInfo(structure, rpNameLookup);
-        expect(result.chainLabels.get('A')).toBe('eS1 [A]');
+        expect(result.chainLabels.get('A')).toBe('eS1 | P61247 [A]');
     });
 
     it('uses species-specific lookup when available', () => {
@@ -220,7 +244,7 @@ describe('getChainInfo with rpNameLookup enrichment', () => {
         } as any;
 
         const result = getChainInfo(structure, rpNameLookupBySpecies);
-        expect(result.chainLabels.get('A')).toBe('HUMAN_FAMILY [AA]');
+        expect(result.chainLabels.get('A')).toBe('HUMAN_FAMILY | P61247 [AA]');
     });
 
     it('falls back to all-species lookup when species is unknown', () => {
@@ -265,6 +289,6 @@ describe('getChainInfo with rpNameLookup enrichment', () => {
         } as any;
 
         const result = getChainInfo(structure, rpNameLookupBySpecies);
-        expect(result.chainLabels.get('A')).toBe('ALL_FAMILY [AA]');
+        expect(result.chainLabels.get('A')).toBe('ALL_FAMILY | P61247 [AA]');
     });
 });

--- a/src/utils/chain.ts
+++ b/src/utils/chain.ts
@@ -11,6 +11,38 @@
 import { Structure } from 'molstar/lib/mol-model/structure';
 import { buildEntityToUniprotMap, inferSpeciesKeyFromModel, RpNameLookupBySpecies } from './rpNameTable';
 
+function buildChainLabel(
+    labelId: string,
+    authId: string,
+    familyName?: string,
+    uniprotAccession?: string,
+    geneName?: string,
+    showUniprotAccessionInLabel = true
+): string {
+    const targetId = labelId || authId;
+    const defaultLabel = labelId ? `${labelId} [auth ${authId}]` : `[auth ${authId}]`;
+
+    if (!familyName && !uniprotAccession && !geneName) {
+        return defaultLabel;
+    }
+
+    const prefixParts: string[] = [];
+    if (familyName) prefixParts.push(familyName);
+    if (geneName && uniprotAccession) {
+        prefixParts.push(showUniprotAccessionInLabel ? `${geneName} (${uniprotAccession})` : geneName);
+    } else if (geneName) {
+        prefixParts.push(geneName);
+    } else if (uniprotAccession && showUniprotAccessionInLabel) {
+        prefixParts.push(uniprotAccession);
+    }
+
+    if (prefixParts.length === 0) {
+        return defaultLabel;
+    }
+
+    return `${prefixParts.join(' | ')} [${targetId}]`;
+}
+
 function isLookupBySpecies(
     lookup?: Map<string, string> | RpNameLookupBySpecies
 ): lookup is RpNameLookupBySpecies {
@@ -34,13 +66,21 @@ function isLookupBySpecies(
  */
 export function getChainInfo(
     structure: Structure,
-    rpNameLookup?: Map<string, string> | RpNameLookupBySpecies
-): { chainLabels: Map<string, string> } {
+    rpNameLookup?: Map<string, string> | RpNameLookupBySpecies,
+    geneNameLookup?: Record<string, string | null>,
+    showUniprotAccessionInLabel = true
+): {
+    chainLabels: Map<string, string>;
+    chainToUniprot: Map<string, string>;
+    uniprotAccessions: Set<string>;
+} {
     const chainLabels: Map<string, string> = new Map();
+    const chainToUniprot: Map<string, string> = new Map();
+    const uniprotAccessions: Set<string> = new Set();
     const units = structure.units;
     if (!units || units.length === 0) {
         console.warn('No units found in structure.');
-        return { chainLabels };
+        return { chainLabels, chainToUniprot, uniprotAccessions };
     }
     units.forEach(unit => {
         // Only process atomic units
@@ -72,12 +112,16 @@ export function getChainInfo(
 
             // Attempt to resolve gene family name via UniProt
             let familyName: string | undefined;
+            let uniprotAccession: string | undefined;
             if (rpNameLookup && entityToUniprot) {
                 const entityId = chains.label_entity_id?.value
                     ? String(chains.label_entity_id.value(i))
                     : undefined;
                 const uniprot = entityId ? entityToUniprot.get(entityId) : undefined;
                 if (uniprot) {
+                    uniprotAccession = uniprot;
+                    uniprotAccessions.add(uniprot);
+                    chainToUniprot.set(authId, uniprot);
                     familyName = activeLookup?.get(uniprot);
                     if (!familyName && isLookupBySpecies(rpNameLookup)) {
                         familyName = rpNameLookup.all.get(uniprot);
@@ -85,14 +129,17 @@ export function getChainInfo(
                 }
             }
 
-            let label: string;
-            if (familyName) {
-                label = `${familyName} [${labelId || authId}]`;
-            } else {
-                label = labelId ? `${labelId} [auth ${authId}]` : `[auth ${authId}]`;
-            }
+            const geneName = uniprotAccession ? geneNameLookup?.[uniprotAccession] ?? undefined : undefined;
+            const label = buildChainLabel(
+                labelId,
+                authId,
+                familyName,
+                uniprotAccession,
+                geneName ?? undefined,
+                showUniprotAccessionInLabel
+            );
             chainLabels.set(authId, label);
         }
     });
-    return { chainLabels };
+    return { chainLabels, chainToUniprot, uniprotAccessions };
 }

--- a/src/utils/uniprot.test.ts
+++ b/src/utils/uniprot.test.ts
@@ -1,0 +1,62 @@
+import { fetchUniProtGeneNames, fetchUniProtGeneNamesBatched } from './uniprot';
+import { vi } from 'vitest';
+
+describe('fetchUniProtGeneNames', () => {
+    it('parses UniProt TSV response and returns primary gene names', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            text: async () => 'Entry\tGene Names (primary)\nP61247\tRPS3A\nP33442\tRPS3A\n',
+        });
+
+        const result = await fetchUniProtGeneNames(['P61247', 'P33442'], fetchMock as any);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({
+            P61247: 'RPS3A',
+            P33442: 'RPS3A',
+        });
+    });
+
+    it('fills unresolved accessions with null', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            text: async () => 'Entry\tGene Names (primary)\nP61247\tRPS3A\n',
+        });
+
+        const result = await fetchUniProtGeneNames(['P61247', 'Q99999'], fetchMock as any);
+
+        expect(result).toEqual({
+            P61247: 'RPS3A',
+            Q99999: null,
+        });
+    });
+});
+
+describe('fetchUniProtGeneNamesBatched', () => {
+    it('marks whole batch as null on request failure and continues', async () => {
+        const fetchMock = vi
+            .fn()
+            .mockResolvedValueOnce({
+                ok: false,
+                status: 429,
+                text: async () => '',
+            })
+            .mockResolvedValueOnce({
+                ok: true,
+                text: async () => 'Entry\tGene Names (primary)\nP3\tG3\n',
+            });
+
+        const result = await fetchUniProtGeneNamesBatched(['P1', 'P2', 'P3'], {
+            batchSize: 2,
+            delayMs: 0,
+            fetchFn: fetchMock as any,
+        });
+
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        expect(result).toEqual({
+            P1: null,
+            P2: null,
+            P3: 'G3',
+        });
+    });
+});

--- a/src/utils/uniprot.ts
+++ b/src/utils/uniprot.ts
@@ -1,0 +1,112 @@
+/**
+ * UniProt API utilities for resolving gene names from UniProt accessions.
+ */
+
+export type UniProtGeneNameCache = Record<string, string | null>;
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function parseTsvGeneResponse(tsv: string): UniProtGeneNameCache {
+    const lines = tsv
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(Boolean);
+
+    if (lines.length <= 1) return {};
+
+    const result: UniProtGeneNameCache = {};
+    for (let i = 1; i < lines.length; i++) {
+        const [accessionRaw, geneRaw] = lines[i].split('\t');
+        const accession = (accessionRaw || '').trim();
+        if (!accession) continue;
+
+        const firstGene = (geneRaw || '')
+            .split(/[\s,;]+/)
+            .map(v => v.trim())
+            .find(Boolean);
+
+        result[accession] = firstGene || null;
+    }
+    return result;
+}
+
+function buildSearchUrl(accessions: string[]): string {
+    const clauses = accessions.map(a => `accession:${a}`).join(' OR ');
+    const query = encodeURIComponent(`(${clauses})`);
+    return `https://rest.uniprot.org/uniprotkb/search?query=${query}&fields=accession,gene_primary&format=tsv&size=${accessions.length}`;
+}
+
+export async function fetchUniProtGeneNames(
+    accessions: string[],
+    fetchFn: FetchLike = fetch,
+): Promise<UniProtGeneNameCache> {
+    const unique = Array.from(new Set(accessions.map(a => a.trim()).filter(Boolean)));
+    if (unique.length === 0) return {};
+
+    const url = buildSearchUrl(unique);
+    const response = await fetchFn(url, {
+        method: 'GET',
+        headers: { 'Accept': 'text/tab-separated-values' },
+    });
+
+    if (!response.ok) {
+        throw new Error(`UniProt lookup failed with status ${response.status}`);
+    }
+
+    const tsv = await response.text();
+    const resolved = parseTsvGeneResponse(tsv);
+
+    for (const accession of unique) {
+        if (!(accession in resolved)) {
+            resolved[accession] = null;
+        }
+    }
+
+    return resolved;
+}
+
+export async function fetchUniProtGeneNamesBatched(
+    accessions: Iterable<string>,
+    options?: {
+        batchSize?: number;
+        delayMs?: number;
+        fetchFn?: FetchLike;
+        signal?: AbortSignal;
+    }
+): Promise<UniProtGeneNameCache> {
+    const {
+        batchSize = 25,
+        delayMs = 1200,
+        fetchFn = fetch,
+        signal,
+    } = options || {};
+
+    const unique = Array.from(new Set(Array.from(accessions).map(a => a.trim()).filter(Boolean)));
+    const result: UniProtGeneNameCache = {};
+
+    for (let i = 0; i < unique.length; i += batchSize) {
+        if (signal?.aborted) {
+            throw new DOMException('Aborted', 'AbortError');
+        }
+
+        const batch = unique.slice(i, i + batchSize);
+        try {
+            const resolved = await fetchUniProtGeneNames(batch, fetchFn);
+            Object.assign(result, resolved);
+        } catch {
+            for (const accession of batch) {
+                result[accession] = null;
+            }
+        }
+
+        if (i + batchSize < unique.length && delayMs > 0) {
+            await sleep(delayMs);
+        }
+    }
+
+    return result;
+}


### PR DESCRIPTION
Highlights
Added UniProt gene-name enrichment for chain labels.
Added background, rate-limited UniProt lookup to avoid overloading the upstream service.
Added session-cached gene-name results so repeated datasets don’t trigger redundant lookups.
Added a Show UniProt accession in chain labels toggle in General Controls.
Persisted/restored the new label-toggle preference in session [uiState](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/b6a47e94e3/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Technical Notes
Chain-label rendering now supports family name, gene name, and optional accession display.
Lookup failures are handled safely with non-blocking fallbacks.
Added regression coverage for chain-label formatting and session save/load persistence of the toggle.
Validation
Full test suite passing: 55 files, 211 tests.