### PR TITLE
v0.8.3 fix: add UniProt lookup progress visibility and persistent cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v0.8.3] - 2026-06-22
+- Added live UniProt lookup status reporting in `General Controls` (cached, pending, and in-flight counts).
+- Added explicit UniProt lookup progress logging and incremental per-batch chain label updates during background resolution.
+- Added local-storage persistence for UniProt lookup results so cache survives browser reloads in addition to session save/load.
+
 ## [v0.8.2] - 2026-06-22
 - Added UniProt gene-name enrichment for chain labels with background, rate-limited lookup and session-cached results.
 - Added a `Show UniProt accession in chain labels` toggle in `General Controls`, persisted in session `uiState` and restored on load.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ribocode1",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ribocode1",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ribocode1",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,6 +108,8 @@ interface SessionUiState {
     showUniprotAccessionInChainLabels?: boolean;
 }
 
+const UNIPROT_CACHE_STORAGE_KEY = 'ribocode-uniprot-gene-cache-v1';
+
 const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
 
     // Store Files and filenames for aligned and alignedTo molecule reloads.
@@ -141,6 +143,9 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
         []
     );
     const [uniprotGeneNames, setUniprotGeneNames] = useState<UniProtGeneNameCache>({});
+    const [pendingUniProtCount, setPendingUniProtCount] = useState(0);
+    const [inFlightUniProtCount, setInFlightUniProtCount] = useState(0);
+    const [completedUniProtCount, setCompletedUniProtCount] = useState(0);
     const uniprotGeneNamesRef = useRef<UniProtGeneNameCache>({});
     const pendingUniProtAccessionsRef = useRef<Set<string>>(new Set());
     const inFlightUniProtAccessionsRef = useRef<Set<string>>(new Set());
@@ -148,7 +153,36 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
 
     useEffect(() => {
         uniprotGeneNamesRef.current = uniprotGeneNames;
+        setCompletedUniProtCount(Object.keys(uniprotGeneNames).length);
     }, [uniprotGeneNames]);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || !window.localStorage) return;
+        try {
+            const raw = window.localStorage.getItem(UNIPROT_CACHE_STORAGE_KEY);
+            if (!raw) return;
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== 'object') return;
+            setUniprotGeneNames(prev => ({ ...parsed, ...prev }));
+            console.info(`[UniProt] Loaded ${Object.keys(parsed).length} cached accession lookups from local storage.`);
+        } catch (err) {
+            console.warn('[UniProt] Failed to read cache from local storage.', err);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || !window.localStorage) return;
+        try {
+            window.localStorage.setItem(UNIPROT_CACHE_STORAGE_KEY, JSON.stringify(uniprotGeneNames));
+        } catch (err) {
+            console.warn('[UniProt] Failed to save cache to local storage.', err);
+        }
+    }, [uniprotGeneNames]);
+
+    const syncUniProtQueueCounts = useCallback(() => {
+        setPendingUniProtCount(pendingUniProtAccessionsRef.current.size);
+        setInFlightUniProtCount(inFlightUniProtAccessionsRef.current.size);
+    }, []);
 
     const processUniProtQueue = useCallback(async () => {
         if (isProcessingUniProtQueueRef.current) return;
@@ -159,6 +193,7 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
             while (pendingUniProtAccessionsRef.current.size > 0) {
                 const pending = Array.from(pendingUniProtAccessionsRef.current);
                 pendingUniProtAccessionsRef.current.clear();
+                syncUniProtQueueCounts();
 
                 const unresolved = pending.filter(accession => {
                     if (accession in uniprotGeneNamesRef.current) return false;
@@ -169,20 +204,29 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
                 if (!unresolved.length) continue;
 
                 unresolved.forEach(accession => inFlightUniProtAccessionsRef.current.add(accession));
-                const resolved = await fetchUniProtGeneNamesBatched(unresolved, {
+                syncUniProtQueueCounts();
+                console.info(`[UniProt] Looking up ${unresolved.length} accession(s) in background.`);
+
+                await fetchUniProtGeneNamesBatched(unresolved, {
                     batchSize: 20,
                     delayMs: 1200,
+                    onBatchResolved: (batch, resolvedBatch) => {
+                        setUniprotGeneNames(prev => ({ ...prev, ...resolvedBatch }));
+                        const matchedCount = Object.values(resolvedBatch).filter(Boolean).length;
+                        console.info(`[UniProt] Batch resolved: ${batch.length} accession(s), ${matchedCount} gene name(s) found.`);
+                    },
                 });
-                setUniprotGeneNames(prev => ({ ...prev, ...resolved }));
                 unresolved.forEach(accession => inFlightUniProtAccessionsRef.current.delete(accession));
+                syncUniProtQueueCounts();
             }
         } finally {
             isProcessingUniProtQueueRef.current = false;
+            syncUniProtQueueCounts();
             if (pendingUniProtAccessionsRef.current.size > 0) {
                 void processUniProtQueue();
             }
         }
-    }, []);
+    }, [syncUniProtQueueCounts]);
 
     const onUniprotAccessionsDiscovered = useCallback((accessions: Iterable<string>) => {
         let hasQueuedAny = false;
@@ -196,10 +240,15 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
             hasQueuedAny = true;
         }
 
+        syncUniProtQueueCounts();
+        if (hasQueuedAny) {
+            console.info(`[UniProt] Queued ${pendingUniProtAccessionsRef.current.size} accession(s) for lookup.`);
+        }
+
         if (hasQueuedAny) {
             void processUniProtQueue();
         }
-    }, [processUniProtQueue]);
+    }, [processUniProtQueue, syncUniProtQueueCounts]);
 
     // Use a ref to always have the latest alignmentData from AlignedTo
     const alignmentDataRef = useRef<any>(null);
@@ -1530,6 +1579,11 @@ const App: React.FC<AppProps> = ({ testForceIsMoleculeAlignedLoaded }) => {
                         setZoomMinRadius={setZoomMinRadius}
                         showUniprotAccessionInChainLabels={showUniprotAccessionInChainLabels}
                         setShowUniprotAccessionInChainLabels={setShowUniprotAccessionInChainLabels}
+                        uniprotLookupStatus={{
+                            completed: completedUniProtCount,
+                            pending: pendingUniProtCount,
+                            inFlight: inFlightUniProtCount,
+                        }}
                         viewerA={viewerA.ref.current}
                         viewerB={viewerB.ref.current}
                         activeViewer={activeViewer}

--- a/src/components/GeneralControls.test.tsx
+++ b/src/components/GeneralControls.test.tsx
@@ -28,6 +28,7 @@ describe('GeneralControls', () => {
       setZoomMinRadius,
       showUniprotAccessionInChainLabels: true,
       setShowUniprotAccessionInChainLabels,
+      uniprotLookupStatus: { completed: 5, pending: 2, inFlight: 1 },
       viewerA: {},
       viewerB: {},
       activeViewer: 'A' as ViewerKey,
@@ -57,6 +58,7 @@ describe('GeneralControls', () => {
     const showUniProtToggle = getByLabelText(/Show UniProt accession in chain labels/i);
     fireEvent.click(showUniProtToggle);
     expect(setShowUniprotAccessionInChainLabels).toHaveBeenCalledWith(false);
+    expect(getByText(/UniProt cache: 5 cached, 2 pending, 1 in-flight/i)).toBeInTheDocument();
 
     // Test SyncButton (actually a select) is rendered and works
     const syncSelect = getByLabelText(/Select Sync/i);
@@ -87,6 +89,7 @@ describe('GeneralControls', () => {
       setZoomMinRadius: vi.fn(),
       showUniprotAccessionInChainLabels: true,
       setShowUniprotAccessionInChainLabels: vi.fn(),
+      uniprotLookupStatus: { completed: 0, pending: 0, inFlight: 0 },
       viewerA: {},
       viewerB: {},
       activeViewer: 'A' as ViewerKey,

--- a/src/components/GeneralControls.tsx
+++ b/src/components/GeneralControls.tsx
@@ -42,6 +42,11 @@ interface GeneralControlsProps {
   setZoomMinRadius: (v: number) => void;
   showUniprotAccessionInChainLabels: boolean;
   setShowUniprotAccessionInChainLabels: (v: boolean) => void;
+  uniprotLookupStatus?: {
+    completed: number;
+    pending: number;
+    inFlight: number;
+  };
   viewerA: any;
   viewerB: any;
   activeViewer: ViewerKey;
@@ -67,6 +72,7 @@ const GeneralControls: React.FC<GeneralControlsProps> = ({
   setZoomMinRadius,
   showUniprotAccessionInChainLabels,
   setShowUniprotAccessionInChainLabels,
+  uniprotLookupStatus,
   viewerA,
   viewerB,
   activeViewer,
@@ -117,6 +123,12 @@ const GeneralControls: React.FC<GeneralControlsProps> = ({
         />
         Show UniProt accession in chain labels
       </label>
+      <span
+        id={`${idPrefix}-uniprot-status`}
+        style={{ fontSize: 12, color: '#555' }}
+      >
+        UniProt cache: {uniprotLookupStatus?.completed ?? 0} cached, {uniprotLookupStatus?.pending ?? 0} pending, {uniprotLookupStatus?.inFlight ?? 0} in-flight
+      </span>
     </div>
     <SyncButton
       viewerA={viewerA}

--- a/src/utils/uniprot.ts
+++ b/src/utils/uniprot.ts
@@ -76,6 +76,7 @@ export async function fetchUniProtGeneNamesBatched(
         delayMs?: number;
         fetchFn?: FetchLike;
         signal?: AbortSignal;
+        onBatchResolved?: (batch: string[], resolved: UniProtGeneNameCache) => void;
     }
 ): Promise<UniProtGeneNameCache> {
     const {
@@ -83,6 +84,7 @@ export async function fetchUniProtGeneNamesBatched(
         delayMs = 1200,
         fetchFn = fetch,
         signal,
+        onBatchResolved,
     } = options || {};
 
     const unique = Array.from(new Set(Array.from(accessions).map(a => a.trim()).filter(Boolean)));
@@ -97,10 +99,14 @@ export async function fetchUniProtGeneNamesBatched(
         try {
             const resolved = await fetchUniProtGeneNames(batch, fetchFn);
             Object.assign(result, resolved);
+            onBatchResolved?.(batch, resolved);
         } catch {
+            const failed: UniProtGeneNameCache = {};
             for (const accession of batch) {
                 result[accession] = null;
+                failed[accession] = null;
             }
+            onBatchResolved?.(batch, failed);
         }
 
         if (i + batchSize < unique.length && delayMs > 0) {


### PR DESCRIPTION
Highlights
Added live UniProt lookup status in General Controls, showing:
cached results
pending lookups
in-flight lookups
Added incremental, per-batch UI updates so chain labels refresh progressively as UniProt lookups resolve.
Added explicit UniProt progress logging to help track lookup activity and outcomes.
Added persistent local cache for UniProt lookup results so data survives browser reloads.
Retained session-based persistence so saved sessions also restore lookup results and label behavior.
User Impact
Chain label enrichment is now visibly active and easier to trust/diagnose.
Users can see whether lookups are queued/running/completed instead of waiting with no feedback.
Repeat sessions and reloads avoid unnecessary UniProt calls thanks to stronger caching.
Validation
Full test suite passing: 55 files, 211 tests.